### PR TITLE
Fix docker test

### DIFF
--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,6 +1,8 @@
 FROM ubuntu:latest
 
 RUN apt-get update && apt-get upgrade -y
+RUN apt-get install software-properties-common -y
+RUN add-apt-repository ppa:deadsnakes/ppa
 RUN apt-get -y install build-essential python3.6 python3.6-dev python3-pip libssl-dev git
 
 WORKDIR /home/elastalert

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,4 @@ pylint<1.4
 pytest<3.3.0
 setuptools
 sphinx_rtd_theme
-tox<2.0
+tox==3.20.1


### PR DESCRIPTION
Fix

Facing issue “virtualenv: error: argument --setuptools: expected one argument” when running jertel/elastalert
https://stackoverflow.com/questions/65020700/facing-issue-virtualenv-error-argument-setuptools-expected-one-argument-w
> I've been trying to run the jertel/elastalert repo. The config.yaml and rules.yaml have both been set up to point at our environment. The only other change has been in setup.py where we changed elasticsearch==7.0.0 to 7.6.0
> 
> When I'm building the docker container though, I get stonewalled by this error.