### PR TITLE
Fix test_rule.py error

### DIFF
--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -83,7 +83,7 @@ class MockElastAlerter(object):
 
         # Get one document for schema
         try:
-            res = es_client.search(index, size=1, body=query, ignore_unavailable=True)
+            res = es_client.search(index=index, size=1, body=query, ignore_unavailable=True)
         except Exception as e:
             print("Error running your filter:", file=sys.stderr)
             print(repr(e)[:2048], file=sys.stderr)
@@ -109,7 +109,7 @@ class MockElastAlerter(object):
             five=conf['five']
         )
         try:
-            res = es_client.count(index, doc_type=doc_type, body=count_query, ignore_unavailable=True)
+            res = es_client.count(index=index, doc_type=doc_type, body=count_query, ignore_unavailable=True)
         except Exception as e:
             print("Error querying Elasticsearch:", file=sys.stderr)
             print(repr(e)[:2048], file=sys.stderr)
@@ -153,7 +153,7 @@ class MockElastAlerter(object):
         # Download up to max_query_size (defaults to 10,000) documents to save
         if (args.save or args.formatted_output) and not args.count:
             try:
-                res = es_client.search(index, size=args.max_query_size, body=query, ignore_unavailable=True)
+                res = es_client.search(index=index, size=args.max_query_size, body=query, ignore_unavailable=True)
             except Exception as e:
                 print("Error running your filter:", file=sys.stderr)
                 print(repr(e)[:2048], file=sys.stderr)


### PR DESCRIPTION
|  elasticsearch-py   |  Test Run   |   Send real alerts  | 
| --- | --- | --- | 
|  7.0.0    |  〇    |  〇   | 
|  7.10.0    |  ✖    |  ✖   |
|  7.10.0    | 〇<br> (fix test_rules.py )    |  ✖   |
|  7.10.0    | 〇<br> (fix test_rules.py )    |  〇<br>([Fix initializing self.thread_data.alerts_sent for running elastalert-test-rule #2991](https://github.com/Yelp/elastalert/pull/2991))   |