### PR TITLE
Fix initializing self.thread_data.alerts_sent for running elastalert-…

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -159,6 +159,7 @@ class ElastAlerter(object):
         self.starttime = self.args.start
         self.disabled_rules = []
         self.replace_dots_in_field_names = self.conf.get('replace_dots_in_field_names', False)
+        self.thread_data.alerts_sent = 0
         self.thread_data.num_hits = 0
         self.thread_data.num_dupes = 0
         self.scheduler = BackgroundScheduler()


### PR DESCRIPTION
Fix for [AttributeError: '_thread._local' object has no attribute 'alerts_sent' #2634](https://github.com/Yelp/elastalert/issues/2634)
