### PR TITLE
Fix example

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -48,7 +48,6 @@ es_port: 9200
 
 # Use SSL authentication with client certificates client_cert must be
 # a pem file containing both cert and key for client
-#verify_certs: True
 #ca_certs: /path/to/cacert.pem
 #client_cert: /path/to/client_cert.pem
 #client_key: /path/to/client_key.key

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -77,38 +77,38 @@ alert_time_limit:
 #    logline:
 #      format: '%(asctime)s %(levelname)+8s %(name)+20s %(message)s'
 #
-#    handlers:
-#      console:
-#        class: logging.StreamHandler
-#        formatter: logline
-#        level: DEBUG
-#        stream: ext://sys.stderr
+#  handlers:
+#    console:
+#      class: logging.StreamHandler
+#      formatter: logline
+#      level: DEBUG
+#      stream: ext://sys.stderr
 #
-#      file:
-#        class : logging.FileHandler
-#        formatter: logline
-#        level: DEBUG
-#        filename: elastalert.log
+#    file:
+#      class : logging.FileHandler
+#      formatter: logline
+#      level: DEBUG
+#      filename: elastalert.log
 #
-#    loggers:
-#      elastalert:
-#        level: WARN
-#        handlers: []
-#        propagate: true
+#  loggers:
+#    elastalert:
+#      level: WARN
+#      handlers: []
+#      propagate: true
 #
-#      elasticsearch:
-#        level: WARN
-#        handlers: []
-#        propagate: true
+#    elasticsearch:
+#      level: WARN
+#      handlers: []
+#      propagate: true
 #
-#      elasticsearch.trace:
-#        level: WARN
-#        handlers: []
-#        propagate: true
+#    elasticsearch.trace:
+#      level: WARN
+#      handlers: []
+#      propagate: true
 #
-#      '':  # root logger
-#        level: WARN
-#          handlers:
-#            - console
-#            - file
-#        propagate: false
+#    '':  # root logger
+#      level: WARN
+#      handlers:
+#        - console
+#        - file
+#      propagate: false

--- a/example_rules/ssh.yaml
+++ b/example_rules/ssh.yaml
@@ -1,5 +1,5 @@
 # Rule name, must be unique
-  name: SSH abuse (ElastAlert 3.0.1) - 2
+name: SSH abuse (ElastAlert 3.0.1) - 2
 
 # Alert on x events in y seconds
 type: frequency


### PR DESCRIPTION
・Typo in example_rules/ssh.yam

・Remove duplicate property in example config file

・Fixed the logging property in config.yaml.example
I was able to output the file.

```
# This is the folder that contains the rule yaml files
# Any .yaml file will be loaded as a rule
rules_folder: rules

# How often ElastAlert will query Elasticsearch
# The unit can be anything from weeks to seconds
run_every:
  minutes: 1

# ElastAlert will buffer results from the most recent
# period of time, in case some log sources are not in real time
buffer_time:
  minutes: 15

# The Elasticsearch hostname for metadata writeback
# Note that every rule can have its own Elasticsearch host
es_host: localhost

# The Elasticsearch port
es_port: 9200

# The AWS region to use. Set this when using AWS-managed elasticsearch
#aws_region: us-east-1

# The AWS profile to use. Use this if you are using an aws-cli profile.
# See http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html
# for details
#profile: test
profile: default

# Optional URL prefix for Elasticsearch
#es_url_prefix: elasticsearch

# Connect with TLS to Elasticsearch
#use_ssl: True

# Verify TLS certificates
#verify_certs: True

# GET request with body is the default option for Elasticsearch.
# If it fails for some reason, you can pass 'GET', 'POST' or 'source'.
# See http://elasticsearch-py.readthedocs.io/en/master/connection.html?highlight=send_get_body_as#transport
# for details
#es_send_get_body_as: GET

# Option basic-auth username and password for Elasticsearch
#es_username: someusername
#es_password: somepassword

# Use SSL authentication with client certificates client_cert must be
# a pem file containing both cert and key for client
#verify_certs: True
#ca_certs: /path/to/cacert.pem
#client_cert: /path/to/client_cert.pem
#client_key: /path/to/client_key.key

# The index on es_host which is used for metadata storage
# This can be a unmapped index, but it is recommended that you run
# elastalert-create-index to set a mapping
writeback_index: elastalert_status
writeback_alias: elastalert_alerts

# If an alert fails for some reason, ElastAlert will retry
# sending the alert until this time period has elapsed
alert_time_limit:
  days: 2

# Custom logging configuration
# If you want to setup your own logging configuration to log into
# files as well or to Logstash and/or modify log levels, use
# the configuration below and adjust to your needs.
# Note: if you run ElastAlert with --verbose/--debug, the log level of
# the "elastalert" logger is changed to INFO, if not already INFO/DEBUG.
logging:
  version: 1
  incremental: false
  disable_existing_loggers: false
  formatters:
    logline:
      format: '%(asctime)s %(levelname)+8s %(name)+20s %(message)s'

  handlers:
    console:
      class: logging.StreamHandler
      formatter: logline
      level: INFO
      stream: ext://sys.stderr

    file:
      class : logging.FileHandler
      formatter: logline
      level: INFO
      filename: elastalert.log

  loggers:
    elastalert:
      level: INFO
      handlers: []
      propagate: true

    elasticsearch:
      level: INFO
      handlers: []
      propagate: true

    elasticsearch.trace:
      level: INFO
      handlers: []
      propagate: true

    '':  # root logger
      level: INFO
      handlers:
        - console
        - file
      propagate: false
```

![1](https://user-images.githubusercontent.com/22293449/102801169-2ebcaf00-43f8-11eb-8518-26f92ff4d854.PNG)
![2](https://user-images.githubusercontent.com/22293449/102801183-31b79f80-43f8-11eb-8059-20664b38d36e.PNG)
