### PR TITLE
Fix ruletypes.rst typo

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -938,7 +938,7 @@ Optional:
 ``field_value``: When set, uses the value of the field in the document and not the number of matching documents.
 This is useful to monitor for example a temperature sensor and raise an alarm if the temperature grows too fast.
 Note that the means of the field on the reference and current windows are used to determine if the ``spike_height`` value is reached.
-Note also that the threshold parameters are ignored in this smode.
+Note also that the threshold parameters are ignored in this mode.
 
 
 ``threshold_ref``: The minimum number of events that must exist in the reference window for an alert to trigger. For example, if


### PR DESCRIPTION
**before**

Note also that the threshold parameters are ignored in this smode.

**after**

Note also that the threshold parameters are ignored in this mode.