### PR TITLE
Remove Duplicate Key in Schema YAML

### DIFF
--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -347,7 +347,6 @@ properties:
   alerta_origin: {type: string}   # Python format string
   alerta_group: {type: string}  # Python format string
   alerta_service: {type: array, items: {type: string}}  # Python format string
-  alerta_service: {type: array, items: {type: string}}  # Python format string
   alerta_correlate: {type: array, items: {type: string}}  # Python format string
   alerta_tags: {type: array, items: {type: string}}   # Python format string
   alerta_event: {type: string} # Python format string


### PR DESCRIPTION
**before**

```yaml
  alerta_service: {type: array, items: {type: string}}  # Python format string
  alerta_service: {type: array, items: {type: string}}  # Python format string
```

**after**

```yaml
  alerta_service: {type: array, items: {type: string}}  # Python format string
```
