### PR TITLE
Add Discord Alerter 

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Currently, we have built-in support for the following alert types:
 - Line Notify
 - TheHive
 - Zabbix
+- Discord
 
 Additional rule types and alerts can be easily imported or written.
 

--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -55,6 +55,7 @@ Currently, we have support built in for these alert types:
 - Line Notify
 - TheHive
 - Zabbix
+- Discord
 
 Additional rule types and alerts can be easily imported or written. (See :ref:`Writing rule types <writingrules>` and :ref:`Writing alerts <writingalerts>`)
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -2297,9 +2297,7 @@ Optional:
 
 ``discord_emoji_title``: By default ElastAlert will use the ``:warning:`` emoji when posting to the channel. You can use a different emoji per ElastAlert rule. Any Apple emoji can be used, see http://emojipedia.org/apple/ . If slack_icon_url_override parameter is provided, emoji is ignored.
 
-``discord_http_proxy``: By default ElastAlert will not use a network http proxy to send notifications to Discord. Set this option using hostname:port if you need to use a proxy.
-
-``discord_https_proxy``: By default ElastAlert will not use a network https proxy to send notifications to Discord. Set this option using hostname:port if you need to use a proxy.
+``discord_proxy``: By default ElastAlert will not use a network proxy to send notifications to Discord. Set this option using hostname:port if you need to use a proxy.
 
 ``discord_proxy_login``: The Discord proxy auth username.
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -2282,3 +2282,31 @@ Required:
 ``zbx_sender_port``: The port where zabbix server is listenning.
 ``zbx_host``: This field setup the host in zabbix that receives the value sent by Elastalert.
 ``zbx_key``: This field setup the key in the host that receives the value sent by Elastalert.
+
+
+Discord
+~~~~~~~
+
+Discord will send notification to a Line application. The body of the notification is formatted the same as with other alerters.
+
+Required:
+
+``discord_webhook_url``:  The webhook URL.
+
+Optional:
+
+``discord_emoji_title``: By default ElastAlert will use the ``:warning:`` emoji when posting to the channel. You can use a different emoji per ElastAlert rule. Any Apple emoji can be used, see http://emojipedia.org/apple/ . If slack_icon_url_override parameter is provided, emoji is ignored.
+
+``discord_http_proxy``: By default ElastAlert will not use a network http proxy to send notifications to Discord. Set this option using hostname:port if you need to use a proxy.
+
+``discord_https_proxy``: By default ElastAlert will not use a network https proxy to send notifications to Discord. Set this option using hostname:port if you need to use a proxy.
+
+``discord_proxy_login``: The Discord proxy auth username.
+
+``discord_proxy_password``: The Discord proxy auth username.
+
+``discord_embed_color``: embed color. By default ``0xffffff``.
+
+``discord_embed_footer``: embed footer.
+
+``discord_embed_icon_url``: You can provide icon_url to use custom image. Provide absolute address of the pciture.

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -2010,3 +2010,65 @@ class HiveAlerter(Alerter):
             'type': 'hivealerter',
             'hive_host': self.rule.get('hive_connection', {}).get('hive_host', '')
         }
+
+
+class DiscordAlerter(Alerter):
+
+    required_options = frozenset(['discord_webhook_url'])
+
+    def __init__(self, rule):
+        super(DiscordAlerter, self).__init__(rule)
+        self.discord_webhook_url = self.rule['discord_webhook_url']
+        self.discord_emoji_title = self.rule.get('discord_emoji_title', ':warning:')
+        self.discord_proxy = self.rule.get('discord_proxy', None)
+        self.discord_proxy_login = self.rule.get('discord_proxy_login', None)
+        self.discord_proxy_password = self.rule.get('discord_proxy_password', None)
+        self.discord_embed_color = self.rule.get('discord_embed_color', 0xffffff)
+        self.discord_embed_footer = self.rule.get('discord_embed_footer', None)
+        self.discord_embed_icon_url = self.rule.get('discord_embed_icon_url', None)
+
+    def alert(self, matches):
+        body = ''
+        title = u'%s' % (self.create_title(matches))
+        for match in matches:
+            body += str(BasicMatchString(self.rule, match))
+            if len(matches) > 1:
+                body += '\n----------------------------------------\n'
+        if len(body) > 2047:
+            body = body[0:1950] + '\n *message was cropped according to discord embed description limits!* '
+
+        body += '```'
+
+        proxies = {'https': self.discord_proxy} if self.discord_proxy else None
+        auth = HTTPProxyAuth(self.discord_proxy_login, self.discord_proxy_password) if self.discord_proxy_login else None
+        headers = {"Content-Type": "application/json"}
+
+        data = {}
+        data["content"] = "%s %s %s" % (self.discord_emoji_title, title, self.discord_emoji_title)
+        data["embeds"] = []
+        embed = {}
+        embed["description"] = "%s" % (body)
+        embed["color"] = (self.discord_embed_color)
+
+        if self.discord_embed_footer:
+            embed["footer"] = {}
+            embed["footer"]["text"] = (self.discord_embed_footer) if self.discord_embed_footer else None
+            embed["footer"]["icon_url"] = (self.discord_embed_icon_url) if self.discord_embed_icon_url else None
+        else:
+            None
+
+        data["embeds"].append(embed)
+
+        try:
+            response = requests.post(self.discord_webhook_url, data=json.dumps(data), headers=headers, proxies=proxies, auth=auth)
+            warnings.resetwarnings()
+            response.raise_for_status()
+        except RequestException as e:
+            raise EAException("Error posting to Discord: %s. Details: %s" % (e, "" if e.response is None else e.response.text))
+
+        elastalert_logger.info(
+                "Alert sent to the webhook %s" % self.discord_webhook_url)
+
+    def get_info(self):
+        return {'type': 'discord',
+                'discord_webhook_url': self.discord_webhook_url}

--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -80,7 +80,8 @@ class RulesLoader(object):
         'pagertree': alerts.PagerTreeAlerter,
         'linenotify': alerts.LineNotifyAlerter,
         'hivealerter': alerts.HiveAlerter,
-        'zabbix': ZabbixAlerter
+        'zabbix': ZabbixAlerter,
+        'discord': alerts.DiscordAlerter
     }
 
     # A partial ordering of alert types. Relative order will be preserved in the resulting alerts list

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -371,3 +371,6 @@ properties:
   zbx_sender_port: {type: integer}
   zbx_host: {type: string}
   zbx_key: {type: string}
+
+  ## Discord
+  discord_webhook_url: {type: string}

--- a/example_rules/exemple_discord_any.yaml
+++ b/example_rules/exemple_discord_any.yaml
@@ -1,0 +1,40 @@
+# This exemple will provide you every alerts that occured between the sleeping time your configured in your config file.
+# Every match will be send as a unique alert to discord. If you got 3 match, the alerter will send 3 alert to your discord.
+
+name: "Exemple discord webhook alert"
+type: any
+index: your_indice_%Y-%m-%d
+use_strftime_index: true
+
+# Exemple query
+filter:
+- query:
+    query_string:
+      query: "id: 2501 OR id: 5503"
+
+realert:
+  minutes: 0
+
+# I only add the code content here. This way, it prevent to encode the entire description section. Only the log will be encoded and it will provide more visibility.
+include: ["timestamp","name","computer"]
+alert_text: "Alerts at {0} on the computer {1}.\n```"
+alert_text_args: ["timestamp","computer"]
+
+# Needed
+alert:
+- discord
+discord_webhook_url: "Your discord webhook url"
+
+# ----- Optional Section -----
+
+discord_proxy: "proxy_address"
+
+# Must be in "" and must be valid emoji supported by discord.
+discord_emoji_title: ":lock:"
+
+# Must be an hexadecimal value according to the exemple below
+discord_embed_color: 0xE24D42
+
+# This content will be displayed at the very end of your embed message. If you don't add one of these 2 lines, the footer will not be added.
+discord_embed_footer: "Message sent by ElastAlert from your computer"
+discord_embed_icon_url: "https://humancoders-formations.s3.amazonaws.com/uploads/course/logo/38/thumb_bigger_formation-elasticsearch.png"


### PR DESCRIPTION
example

```yaml
alert:
  - discord
alert_subject: a
alert_subject_args: []
alert_text: b
alert_text_args: []
discord_webhook_url: 'https://discord.com/api/webhooks/xxxx/xxxx'
discord_emoji_title: ':lock:'
discord_embed_color: 0xE24D42
discord_embed_footer: 'Message sent by ElastAlert from your computer'
discord_embed_icon_url: 'https://humancoders-formations.s3.amazonaws.com/uploads/course/logo/38/thumb_bigger_formation-elasticsearch.png'
filter:
  - query:
      query_string:
        query: 'message:Quit'
index: mariadblog-*
is_enabled: true
name: a
realert:
  minutes: 1
timestamp_field: '@timestamp'
timestamp_type: iso
type: any
use_strftime_index: false
```

![キャプチャ](https://user-images.githubusercontent.com/22293449/104850376-188c0b00-5932-11eb-87c0-00b7a4ed1ef2.PNG)
