### PR TITLE
Add Chatwork Alerter / Fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Currently, we have built-in support for the following alert types:
 - Zabbix
 - Discord
 - Dingtalk
+- Chatwork
 
 Additional rule types and alerts can be easily imported or written.
 

--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -57,6 +57,7 @@ Currently, we have support built in for these alert types:
 - Zabbix
 - Discord
 - Dingtalk
+- Chatwork
 
 Additional rule types and alerts can be easily imported or written. (See :ref:`Writing rule types <writingrules>` and :ref:`Writing alerts <writingalerts>`)
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -2292,7 +2292,7 @@ Required:
 Discord
 ~~~~~~~
 
-Discord will send notification to a Line application. The body of the notification is formatted the same as with other alerters.
+Discord will send notification to a Discord application. The body of the notification is formatted the same as with other alerters.
 
 Required:
 
@@ -2317,7 +2317,7 @@ Optional:
 Dingtalk
 ~~~~~~~~
 
-Dingtalk will send notification to a Line application. The body of the notification is formatted the same as with other alerters.
+Dingtalk will send notification to a Dingtalk application. The body of the notification is formatted the same as with other alerters.
 
 Required:
 
@@ -2373,3 +2373,21 @@ Example msgtype : action_card::
     dingtalk_msgtype: 'action_card'
     dingtalk_btn_orientation: '0'
     dingtalk_btns: [{'title': 'a', 'actionURL': 'https://xxxx1.xxx'}, {'title': 'b', 'actionURL': 'https://xxxx2.xxx'}]
+
+Chatwork
+~~~~~~~~
+
+Chatwork will send notification to a Chatwork application. The body of the notification is formatted the same as with other alerters.
+
+Required:
+
+``chatwork_apikey``:  ChatWork API KEY.
+
+``chatwork_room_id``: The ID of the room you are talking to in Chatwork. How to find the room ID is the part of the number after "rid" at the end of the URL of the browser.
+
+Example usage::
+
+    alert:
+    - chatwork
+    chatwork_apikey: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+    chatwork_room_id: 'xxxxxxxxx'

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -2191,3 +2191,42 @@ class DingTalkAlerter(Alerter):
             "type": "dingtalk",
             "dingtalk_webhook_url": self.dingtalk_webhook_url
         }
+
+
+class ChatworkAlerter(Alerter):
+    """ Creates a Chatwork room message for each alert """
+    required_options = frozenset(['chatwork_apikey', 'chatwork_room_id'])
+
+    def __init__(self, rule):
+        super(ChatworkAlerter, self).__init__(rule)
+        self.chatwork_apikey = self.rule.get('chatwork_apikey')
+        self.chatwork_room_id = self.rule.get('chatwork_room_id')
+        self.url = 'https://api.chatwork.com/v2/rooms/%s/messages' % (self.chatwork_room_id)
+        self.chatwork_proxy = self.rule.get('chatwork_proxy', None)
+        self.chatwork_proxy_login = self.rule.get('chatwork_proxy_login', None)
+        self.chatwork_proxy_pass = self.rule.get('chatwork_proxy_pass', None)
+
+    def alert(self, matches):
+        body = self.create_alert_body(matches)
+
+        headers = {'X-ChatWorkToken': self.chatwork_apikey}
+        # set https proxy, if it was provided
+        proxies = {'https': self.chatwork_proxy} if self.chatwork_proxy else None
+        auth = HTTPProxyAuth(self.chatwork_proxy_login, self.chatwork_proxy_pass) if self.chatwork_proxy_login else None
+        params = {'body': body}
+
+        try:
+            response = requests.post(self.url, params=params, headers=headers, proxies=proxies, auth=auth)
+            warnings.resetwarnings()
+            response.raise_for_status()
+        except RequestException as e:
+            raise EAException("Error posting to Chattwork: %s. Details: %s" % (e, "" if e.response is None else e.response.text))
+
+        elastalert_logger.info(
+            "Alert sent to Chatwork room %s" % self.chatwork_room_id)
+
+    def get_info(self):
+        return {
+            "type": "chatwork",
+            "chatwork_room_id": self.chatwork_room_id
+        }

--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -82,7 +82,8 @@ class RulesLoader(object):
         'hivealerter': alerts.HiveAlerter,
         'zabbix': ZabbixAlerter,
         'discord': alerts.DiscordAlerter,
-        'dingtalk': alerts.DingTalkAlerter
+        'dingtalk': alerts.DingTalkAlerter,
+        'chatwork': alerts.ChatworkAlerter
     }
 
     # A partial ordering of alert types. Relative order will be preserved in the resulting alerts list

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -383,3 +383,7 @@ properties:
   dingtalk_single_title: {type: string}
   dingtalk_single_url: {type: string}
   dingtalk_btn_orientation: {type: string}
+
+  ### Chatwork
+  chatwork_apikey: {type: string}
+  chatwork_room_id: {type: string}


### PR DESCRIPTION
**Add Chatwork Alerter**

example

```
 alert:
  - chatwork
  chatwork_apikey: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
  chatwork_room_id: 'xxxxxxxxx'
```
![1](https://user-images.githubusercontent.com/22293449/106359732-d615f580-6357-11eb-8068-583d3e7636fe.PNG)


**Fix a typo**
  ruletypes.rst



