### PR TITLE
Update requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,10 @@
 -r requirements.txt
-coverage==4.5.4
+coverage==5.4
 flake8
+pluggy>=0.12.0
 pre-commit
-pylint<1.4
-pytest<3.3.0
+pylint<2.7
+pytest<3.7.0
 setuptools
 sphinx_rtd_theme
-tox==3.20.1
+tox==3.21.4


### PR DESCRIPTION
- coverage==4.5.4 to coverage==5.4
- add pluggy>=0.12.0
- pylint<1.4 to pylint<2.7
- pytest<3.3.0 to pytest<3.7.0
- tox==3.20.1 to tox==3.21.4

```
[CORP\sano@a-ngft53r34ong elastalert]$ make test-docker
docker-compose --project-name elastalert build tox
Building tox
Step 1/8 : FROM ubuntu:latest
 ---> f643c72bc252
Step 2/8 : RUN apt-get update && apt-get upgrade -y
 ---> Using cache
 ---> ecfcf69718e0
Step 3/8 : RUN apt-get install software-properties-common -y
 ---> Using cache
 ---> e870cdf200a5
Step 4/8 : RUN add-apt-repository ppa:deadsnakes/ppa
 ---> Using cache
 ---> 6fd45716ef10
Step 5/8 : RUN apt-get -y install build-essential python3.6 python3.6-dev python3-pip libssl-dev git
 ---> Using cache
 ---> 9c51985aea44
Step 6/8 : WORKDIR /home/elastalert
 ---> Using cache
 ---> fd043fc7aeef
Step 7/8 : ADD requirements*.txt ./
 ---> Using cache
 ---> fa4a01dec454
Step 8/8 : RUN pip3 install -r requirements-dev.txt
 ---> Using cache
 ---> e68eed526cee
Successfully built e68eed526cee
Successfully tagged elastalert_tox:latest
docker-compose --project-name elastalert run tox
GLOB sdist-make: /home/elastalert/setup.py
py36 create: /home/elastalert/.tox/py36
py36 installdeps: -rrequirements-dev.txt
py36 inst: /home/elastalert/.tox/.tmp/package/1/elastalert-0.2.4.zip
py36 installed: alabaster==0.7.12,appdirs==1.4.4,APScheduler==3.7.0,astroid==2.4.2,attrs==20.3.0,aws-requests-auth==0.4.3,Babel==2.9.0,boto3==1.17.6,botocore==1.20.6,certifi==2020.12.5,cffi==1.14.5,cfgv==3.2.0,chardet==4.0.0,configparser==5.0.1,coverage==5.4,croniter==1.0.6,cryptography==3.4.4,defusedxml==0.6.0,distlib==0.3.1,docopt==0.6.2,docutils==0.16,elastalert @ file:///home/elastalert/.tox/.tmp/package/1/elastalert-0.2.4.zip,elasticsearch==7.0.0,envparse==0.2.0,exotel==0.1.5,filelock==3.0.12,flake8==3.8.4,future==0.18.2,identify==1.5.13,idna==2.10,imagesize==1.2.0,importlib-metadata==3.4.0,importlib-resources==5.1.0,isort==5.7.0,Jinja2==2.10.1,jira==2.0.0,jmespath==0.10.0,jsonschema==3.2.0,lazy-object-proxy==1.4.3,MarkupSafe==1.1.1,mccabe==0.6.1,mock==4.0.3,natsort==7.1.1,nodeenv==1.5.0,oauthlib==3.1.0,packaging==20.9,pbr==5.5.1,pluggy==0.13.1,pre-commit==2.10.1,prison==0.1.3,py==1.10.0,py-zabbix==1.1.7,pycodestyle==2.6.0,pycparser==2.20,pyflakes==2.2.0,Pygments==2.7.4,PyJWT==2.0.1,pylint==2.6.0,pyparsing==2.4.7,pyrsistent==0.17.3,PySocks==1.7.1,PyStaticConfiguration==0.10.5,pytest==3.2.5,python-dateutil==2.6.1,pytz==2021.1,PyYAML==5.4.1,requests==2.25.1,requests-oauthlib==1.3.0,requests-toolbelt==0.9.1,s3transfer==0.3.4,six==1.15.0,snowballstemmer==2.1.0,sortedcontainers==2.3.0,Sphinx==3.4.3,sphinx-rtd-theme==0.5.1,sphinxcontrib-applehelp==1.0.2,sphinxcontrib-devhelp==1.0.2,sphinxcontrib-htmlhelp==1.0.3,sphinxcontrib-jsmath==1.0.1,sphinxcontrib-qthelp==1.0.3,sphinxcontrib-serializinghtml==1.1.4,stomp.py==6.1.0,texttable==1.6.3,toml==0.10.2,tox==3.21.4,twilio==6.0.0,typed-ast==1.4.2,typing-extensions==3.7.4.3,tzlocal==2.1,urllib3==1.26.3,virtualenv==20.4.2,wrapt==1.12.1,zipp==3.4.0
py36 run-test-pre: PYTHONHASHSEED='3919656547'
py36 run-test: commands[0] | coverage run --source=elastalert/,tests/ -m pytest --strict
========================================================================== test session starts ==========================================================================
platform linux -- Python 3.6.12, pytest-3.2.5, py-1.10.0, pluggy-0.4.0
rootdir: /home/elastalert, inifile: pytest.ini
collected 253 items                                                                                                                                                      

tests/alerts_test.py .........................................................
tests/auth_test.py ...
tests/base_test.py ........................................................
tests/create_index_test.py ..................
tests/elasticsearch_test.py ssss
tests/kibana_discover_test.py ........................................
tests/kibana_test.py ....
tests/loaders_test.py .....................
tests/rules_test.py ..................................
tests/util_test.py ................

================================================================ 249 passed, 4 skipped in 34.12 seconds =================================================================
py36 run-test: commands[1] | coverage report -m
Name                             Stmts   Miss  Cover   Missing
--------------------------------------------------------------
elastalert/__init__.py              59     40    32%   19-32, 39, 46-55, 61, 67, 73-74, 80-81, 87, 93-103, 247-257
elastalert/alerts.py              1382    602    56%   46-49, 70, 113, 142, 204, 215, 220, 265, 270, 275-300, 313, 318, 329-384, 387, 394-401, 404, 444-445, 452, 461-470, 486-489, 492, 500-503, 521, 599-606, 617, 625-626, 637, 648, 669, 684, 691, 704, 711, 737-741, 746, 761, 764, 782-785, 804-805, 811-812, 817-818, 820-824, 827-828, 831, 854, 858-859, 868, 874, 881, 886, 895, 900, 923-924, 934-935, 939, 942, 951-957, 960-961, 964-981, 1026-1027, 1031, 1069-1071, 1076, 1080-1085, 1112, 1115, 1120, 1123, 1138, 1151-1152, 1156, 1165-1182, 1185-1187, 1190-1193, 1196-1208, 1211-1261, 1264, 1309-1311, 1361-1362, 1366-1369, 1373-1384, 1395-1397, 1406, 1415-1417, 1421-1436, 1439, 1447-1452, 1455-1464, 1467, 1474-1478, 1481-1491, 1494, 1503-1511, 1514-1534, 1537, 1546-1553, 1556-1584, 1588, 1597-1605, 1608-1615, 1618-1633, 1636-1653, 1656-1657, 1661-1674, 1677, 1686-1689, 1692-1708, 1711, 1731-1733, 1736-1767, 1770, 1809, 1819-1820, 1824-1830, 1833, 1851, 1855, 1879-1880, 1914, 1926-1927, 1931, 1940-1941, 1944-1958, 1961, 1973-2034, 2038, 2049-2057, 2060-2098, 2102, 2111-2121, 2124, 2127-2187, 2190, 2201-2207, 2210-2225, 2229
elastalert/auth.py                  23      3    87%   28, 32, 36
elastalert/config.py                73     20    73%   47-50, 61-62, 65, 69, 84, 88, 91-92, 101, 111, 114, 125, 131, 134-136
elastalert/create_index.py         157    127    19%   23-113, 137, 141-142, 146, 150-264, 268
elastalert/elastalert.py          1277    418    67%   122, 127, 130, 139-141, 180-181, 183, 187, 239, 246-247, 254-286, 294-308, 327, 332, 349-350, 386, 397, 405-411, 418, 432, 469, 473-478, 483-502, 527-535, 542, 551-593, 628, 630, 641, 656, 658, 664-668, 671-675, 699-702, 712-713, 755, 759-762, 768-778, 797, 813-816, 831, 846, 878, 889-890, 909, 912-913, 918, 951, 986-990, 996-1005, 1009-1013, 1067, 1081-1089, 1095-1096, 1098-1122, 1143-1144, 1146, 1156, 1164-1171, 1188-1191, 1194, 1240-1245, 1248-1250, 1254-1256, 1259-1318, 1322-1328, 1340-1341, 1345-1354, 1398-1401, 1428, 1433-1434, 1452, 1458-1465, 1471-1472, 1481, 1488-1506, 1510-1519, 1522-1524, 1527-1529, 1541-1544, 1547, 1551-1553, 1565-1567, 1593, 1596-1599, 1615, 1625-1626, 1634, 1654, 1660, 1666-1668, 1679-1681, 1689, 1716, 1719-1720, 1725-1734, 1749, 1757, 1760-1761, 1772, 1776, 1781-1785, 1800-1804, 1820-1821, 1867-1868, 1871-1872, 1877, 1883-1885, 1888-1889, 1910, 1914, 1923-1927, 1932-1935, 1937-1944, 1974-1975, 1977-1985, 1988, 2004-2005, 2058, 2063-2065, 2069-2074, 2078
elastalert/enhancements.py          11      2    82%   15, 20
elastalert/kibana.py                79     12    85%   209-210, 232-238, 268, 271, 274, 279
elastalert/kibana_discover.py       61      0   100%
elastalert/loaders.py              323     89    72%   124-125, 127, 144, 154, 163, 172, 242, 247, 251, 253, 255, 257, 259, 261, 263, 268-269, 292-313, 317-320, 324, 327, 340-341, 344-345, 355, 361, 374, 385-386, 391-393, 399, 403, 410-416, 425, 431, 435-436, 454, 459, 484-489, 501, 508, 519-523, 528-529, 544-550
elastalert/opsgenie.py             137     24    82%   52-53, 60, 68, 73, 92, 98, 122-123, 130-132, 139, 144-158
elastalert/rule_from_kibana.py      29     29     0%   3-47
elastalert/ruletypes.py            767    187    76%   46, 77, 84, 90, 95, 109-112, 119, 226, 271, 284-291, 334, 343-354, 358-361, 365-368, 371, 376-396, 422, 441, 443-451, 463-468, 499-505, 522-523, 538-539, 553-568, 573-583, 632-640, 665-667, 671, 673, 676, 678-682, 686-688, 697, 699, 714-715, 726, 737, 742, 758-761, 763, 771-781, 939, 988, 992-1003, 1022, 1032, 1056, 1074, 1076, 1081-1088, 1093, 1102, 1115, 1156-1170, 1174-1179, 1187-1198, 1205-1227, 1233-1240
elastalert/test_rule.py            282    251    11%   37-41, 46-47, 52-167, 171-175, 179-197, 201-216, 220-223, 231-337, 343-440, 444-445, 449
elastalert/util.py                 256     74    71%   29-30, 155-156, 168-174, 178-182, 191-193, 255, 259, 263-264, 268, 319-327, 335-388, 394-397, 446
elastalert/zabbix.py                58     46    21%   13-20, 26-41, 52-60, 68-89, 95
tests/__init__.py                    0      0   100%
tests/alerts_test.py               819      1    99%   987
tests/auth_test.py                  11      0   100%
tests/base_test.py                 913      2    99%   31-32
tests/conftest.py                  148     13    91%   26-29, 103-111
tests/create_index_test.py          28      0   100%
tests/elasticsearch_test.py         67     46    31%   24-25, 35-51, 55-71, 75-88, 92-102
tests/kibana_discover_test.py       84      0   100%
tests/kibana_test.py                28      0   100%
tests/loaders_test.py              299      0   100%
tests/rules_test.py                715      0   100%
tests/util_test.py                  93      0   100%
--------------------------------------------------------------
TOTAL                             8179   1986    76%
py36 run-test: commands[2] | flake8 .
docs create: /home/elastalert/.tox/docs
docs installdeps: -rrequirements-dev.txt, sphinx==1.6.6
docs inst: /home/elastalert/.tox/.tmp/package/1/elastalert-0.2.4.zip
docs installed: alabaster==0.7.12,appdirs==1.4.4,APScheduler==3.7.0,astroid==2.4.2,attrs==20.3.0,aws-requests-auth==0.4.3,Babel==2.9.0,boto3==1.17.6,botocore==1.20.6,certifi==2020.12.5,cffi==1.14.5,cfgv==3.2.0,chardet==4.0.0,configparser==5.0.1,coverage==5.4,croniter==1.0.6,cryptography==3.4.4,defusedxml==0.6.0,distlib==0.3.1,docopt==0.6.2,docutils==0.16,elastalert @ file:///home/elastalert/.tox/.tmp/package/1/elastalert-0.2.4.zip,elasticsearch==7.0.0,envparse==0.2.0,exotel==0.1.5,filelock==3.0.12,flake8==3.8.4,future==0.18.2,identify==1.5.13,idna==2.10,imagesize==1.2.0,isort==5.7.0,Jinja2==2.10.1,jira==2.0.0,jmespath==0.10.0,jsonschema==3.2.0,lazy-object-proxy==1.4.3,MarkupSafe==1.1.1,mccabe==0.6.1,mock==4.0.3,natsort==7.1.1,nodeenv==1.5.0,oauthlib==3.1.0,packaging==20.9,pbr==5.5.1,pluggy==0.13.1,pre-commit==2.10.1,prison==0.1.3,py==1.10.0,py-zabbix==1.1.7,pycodestyle==2.6.0,pycparser==2.20,pyflakes==2.2.0,Pygments==2.7.4,PyJWT==2.0.1,pylint==2.6.0,pyparsing==2.4.7,pyrsistent==0.17.3,PySocks==1.7.1,PyStaticConfiguration==0.10.5,pytest==3.2.5,python-dateutil==2.6.1,pytz==2021.1,PyYAML==5.4.1,requests==2.25.1,requests-oauthlib==1.3.0,requests-toolbelt==0.9.1,s3transfer==0.3.4,six==1.15.0,snowballstemmer==2.1.0,sortedcontainers==2.3.0,Sphinx==1.6.6,sphinx-rtd-theme==0.5.1,sphinxcontrib-serializinghtml==1.1.4,sphinxcontrib-websupport==1.2.4,stomp.py==6.1.0,texttable==1.6.3,toml==0.10.2,tox==3.21.4,twilio==6.0.0,tzlocal==2.1,urllib3==1.26.3,virtualenv==20.4.2,wrapt==1.12.1
docs run-test-pre: PYTHONHASHSEED='3919656547'
docs run-test: commands[0] | sphinx-build -b html -d build/doctrees -W source build/html
Running Sphinx v1.6.6
making output directory...
loading pickled environment... not yet created
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 12 source files that are out of date
updating environment: 12 added, 0 changed, 0 removed
reading sources... [  8%] elastalert
reading sources... [ 16%] elastalert_status
reading sources... [ 25%] elasticsearch_security_privileges
reading sources... [ 33%] index
reading sources... [ 41%] recipes/adding_alerts
reading sources... [ 50%] recipes/adding_enhancements
reading sources... [ 58%] recipes/adding_loaders
reading sources... [ 66%] recipes/adding_rules
reading sources... [ 75%] recipes/signing_requests
reading sources... [ 83%] recipes/writing_filters
reading sources... [ 91%] ruletypes
reading sources... [100%] running_elastalert
/home/elastalert/.tox/docs/lib/python3.8/site-packages/sphinx/util/nodes.py:55: FutureWarning: 
   The iterable returned by Node.traverse()
   will become an iterator instead of a list in Docutils > 0.16.
  for classifier in reversed(node.parent.traverse(nodes.classifier)):

looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [  8%] elastalert
writing output... [ 16%] elastalert_status
writing output... [ 25%] elasticsearch_security_privileges
writing output... [ 33%] index
writing output... [ 41%] recipes/adding_alerts
writing output... [ 50%] recipes/adding_enhancements
writing output... [ 58%] recipes/adding_loaders
writing output... [ 66%] recipes/adding_rules
writing output... [ 75%] recipes/signing_requests
writing output... [ 83%] recipes/writing_filters
writing output... [ 91%] ruletypes
writing output... [100%] running_elastalert

generating indices... genindex
writing additional pages... search
copying static files... done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded.
________________________________________________________________________________ summary ________________________________________________________________________________
  py36: commands succeeded
  docs: commands succeeded
  congratulations :)

```