### PR TITLE
Creates a new rule config parameter that "use_local_time_for_query"

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -698,7 +698,7 @@ scan the same range again, triggering duplicate alerts.
 Some rules and alerts require additional options, which also go in the top level of the rule configuration file.
 
 use_local_time_for_query
-^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 ``use_local_time_for_query``: Whether to convert UTC time to the local time zone in rule queries. 
 If false, start and end time of query will be used UTC. (Optional, boolean, default false)

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -102,7 +102,7 @@ Rule Configuration Cheat Sheet
 +--------------------------------------------------------------+           |
 | ``scan_entire_timeframe`` (bool, default False)              |           |
 +--------------------------------------------------------------+           |
-| ``use_local_time_for_query`` (bool, default False)           |           |
+| ``query_timezone`` (string, default empty string)            |           |
 +--------------------------------------------------------------+           |
 | ``import`` (string)                                          |           |
 |                                                              |           |
@@ -697,11 +697,13 @@ scan the same range again, triggering duplicate alerts.
 
 Some rules and alerts require additional options, which also go in the top level of the rule configuration file.
 
-use_local_time_for_query
-^^^^^^^^^^^^^^^^^^^^^^^^
+query_timezone
+^^^^^^^^^^^^^^
 
-``use_local_time_for_query``: Whether to convert UTC time to the local time zone in rule queries. 
-If false, start and end time of query will be used UTC. (Optional, boolean, default false)
+``query_timezone``: Whether to convert UTC time to the specified time zone in rule queries. 
+If not set, start and end time of query will be used UTC. (Optional, string, default empty string)
+
+Example value : query_timezone: "Europe/Istanbul"
 
 .. _testing :
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -102,6 +102,8 @@ Rule Configuration Cheat Sheet
 +--------------------------------------------------------------+           |
 | ``scan_entire_timeframe`` (bool, default False)              |           |
 +--------------------------------------------------------------+           |
+| ``use_local_time_for_query`` (bool, default False)           |           |
++--------------------------------------------------------------+           |
 | ``import`` (string)                                          |           |
 |                                                              |           |
 | IGNORED IF ``use_count_query`` or ``use_terms_query`` is true|           |
@@ -695,6 +697,11 @@ scan the same range again, triggering duplicate alerts.
 
 Some rules and alerts require additional options, which also go in the top level of the rule configuration file.
 
+use_local_time_for_query
+^^^^^^^^^^^^^^^^^^^^^
+
+``use_local_time_for_query``: Whether to convert UTC time to the local time zone in rule queries. 
+If false, start and end time of query will be used UTC. (Optional, boolean, default false)
 
 .. _testing :
 

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -53,6 +53,7 @@ from .util import ts_add
 from .util import ts_now
 from .util import ts_to_dt
 from .util import unix_to_dt
+from .util import ts_utc_to_local
 
 
 class ElastAlerter(object):
@@ -628,6 +629,10 @@ class ElastAlerter(object):
             start = self.get_index_start(rule['index'])
         if end is None:
             end = ts_now()
+
+        if rule.get('use_local_time_for_query'):
+            start = ts_utc_to_local(start)
+            end = ts_utc_to_local(end)
 
         # Reset hit counter and query
         rule_inst = rule['type']

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -53,7 +53,7 @@ from .util import ts_add
 from .util import ts_now
 from .util import ts_to_dt
 from .util import unix_to_dt
-from .util import ts_utc_to_local
+from .util import ts_utc_to_tz
 
 
 class ElastAlerter(object):
@@ -630,9 +630,10 @@ class ElastAlerter(object):
         if end is None:
             end = ts_now()
 
-        if rule.get('use_local_time_for_query'):
-            start = ts_utc_to_local(start)
-            end = ts_utc_to_local(end)
+        if rule.get('query_timezone') != "":
+            elastalert_logger.info("Query start and end time converting UTC to query_timezone : {}".format(rule.get('query_timezone')))
+            start = ts_utc_to_tz(start, rule.get('query_timezone'))
+            end = ts_utc_to_tz(end, rule.get('query_timezone'))
 
         # Reset hit counter and query
         rule_inst = rule['type']

--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -283,7 +283,7 @@ class RulesLoader(object):
         rule.setdefault('use_local_time', True)
         rule.setdefault('description', "")
         rule.setdefault('jinja_root_name', "_data")
-        rule.setdefault('use_local_time_for_query', False)
+        rule.setdefault('query_timezone', "")
 
         # Set timestamp_type conversion function, used when generating queries and processing hits
         rule['timestamp_type'] = rule['timestamp_type'].strip().lower()

--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -283,6 +283,7 @@ class RulesLoader(object):
         rule.setdefault('use_local_time', True)
         rule.setdefault('description', "")
         rule.setdefault('jinja_root_name', "_data")
+        rule.setdefault('use_local_time_for_query', False)
 
         # Set timestamp_type conversion function, used when generating queries and processing hits
         rule['timestamp_type'] = rule['timestamp_type'].strip().lower()

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -186,7 +186,7 @@ def ts_now():
     return datetime.datetime.utcnow().replace(tzinfo=dateutil.tz.tzutc())
 
 
-def ts_utc_to_tz(ts,tz_name):
+def ts_utc_to_tz(ts, tz_name):
     """Convert utc time to local time."""
     return ts.astimezone(dateutil.tz.gettz(tz_name))
 

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -186,9 +186,9 @@ def ts_now():
     return datetime.datetime.utcnow().replace(tzinfo=dateutil.tz.tzutc())
 
 
-def ts_utc_to_local(ts):
+def ts_utc_to_tz(ts,tz_name):
     """Convert utc time to local time."""
-    return ts.astimezone(dateutil.tz.tzlocal())
+    return ts.astimezone(dateutil.tz.gettz(tz_name))
 
 
 def inc_ts(timestamp, milliseconds=1):

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -185,9 +185,11 @@ def dt_to_ts_with_format(dt, ts_format):
 def ts_now():
     return datetime.datetime.utcnow().replace(tzinfo=dateutil.tz.tzutc())
 
+
 def ts_utc_to_local(ts):
     """Convert utc time to local time."""
     return ts.astimezone(dateutil.tz.tzlocal())
+
 
 def inc_ts(timestamp, milliseconds=1):
     """Increment a timestamp by milliseconds."""

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -185,6 +185,9 @@ def dt_to_ts_with_format(dt, ts_format):
 def ts_now():
     return datetime.datetime.utcnow().replace(tzinfo=dateutil.tz.tzutc())
 
+def ts_utc_to_local(ts):
+    """Convert utc time to local time."""
+    return ts.astimezone(dateutil.tz.tzlocal())
 
 def inc_ts(timestamp, milliseconds=1):
     """Increment a timestamp by milliseconds."""
@@ -202,7 +205,7 @@ def pretty_ts(timestamp, tz=True):
         dt = ts_to_dt(timestamp)
     if tz:
         dt = dt.astimezone(dateutil.tz.tzlocal())
-    return dt.strftime('%Y-%m-%d %H:%M %Z')
+    return dt.strftime('%Y-%m-%d %H:%M %z')
 
 
 def ts_add(ts, td):


### PR DESCRIPTION
Hi,
I needed to query indices with local time. So, i created a common parameter that "use_local_time_for_query".

----

It provide that use local time when query in "run_query".  So, filters able to use local time can create. Indices able to have @timestap field with different timezone from "UTC" can be.

``use_local_time_for_query``: Whether to convert UTC time to the local time zone in rule queries. 
If false, start and end time of query will be used UTC. (Optional, boolean, default false)