### PR TITLE
allow alerta_severity to be set dynamically

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1856,7 +1856,7 @@ class AlertaAlerter(Alerter):
 
         alerta_payload_dict = {
             'resource': resolve_string(self.resource, match, self.missing_text),
-            'severity': self.severity,
+            'severity': resolve_string(self.severity, match),
             'timeout': self.timeout,
             'createTime': createTime,
             'type': self.type,

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -343,7 +343,7 @@ properties:
   ### Alerta
   alerta_api_url: {type: string}
   alerta_api_key: {type: string}
-  alerta_severity: {enum: [unknown, security, debug, informational, ok, normal, cleared, indeterminate, warning, minor, major, critical]}
+  alerta_severity: {type: string}
   alerta_resource: {type: string}   # Python format string
   alerta_environment: {type: string}  # Python format string
   alerta_origin: {type: string}   # Python format string


### PR DESCRIPTION
As Alerta has its own validation on the severity value, this PR makes `elastalert` more flexible when it comes to setting the severity using `Enhancements` and then populate the value to `alerta_severity` directive. what do you think?