### PR TITLE
Remove mention of new alert platforms from the old README

### DIFF
--- a/README-old.md
+++ b/README-old.md
@@ -67,9 +67,6 @@ Currently, we have built-in support for the following alert types:
 - Line Notify
 - TheHive
 - Zabbix
-- Discord
-- Dingtalk
-- Chatwork
 
 Additional rule types and alerts can be easily imported or written.
 


### PR DESCRIPTION
As requested by the author of these alerters, @nsano-rururu

The alerts are already documented on https://elastalert2.readthedocs.io