### PR TITLE
Docker test python 3.6 to 3.9

### DIFF
--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,9 +1,9 @@
 FROM ubuntu:latest
 
-RUN apt-get update && apt-get upgrade -y
-RUN apt-get install software-properties-common -y
+RUN apt update && apt upgrade -y
+RUN apt install software-properties-common -y
 RUN add-apt-repository ppa:deadsnakes/ppa
-RUN apt-get -y install build-essential python3.6 python3.6-dev python3-pip libssl-dev git
+RUN apt -y install build-essential python3.9 python3.9-dev python3-pip libssl-dev git
 
 WORKDIR /home/elastalert
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 project = elastalert
-envlist = py36,docs
+envlist = py39,docs
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION


```
[CORP\sano@a-ngft53r34ong elastalert]$ make test-docker
docker-compose --project-name elastalert build tox
Building tox
Step 1/8 : FROM ubuntu:latest
 ---> f643c72bc252
Step 2/8 : RUN apt update && apt upgrade -y
 ---> Using cache
 ---> 4e99cbb35524
Step 3/8 : RUN apt install software-properties-common -y
 ---> Using cache
 ---> 29f379cf15fb
Step 4/8 : RUN add-apt-repository ppa:deadsnakes/ppa
 ---> Using cache
 ---> 9bfa3c4e2450
Step 5/8 : RUN apt -y install build-essential python3.9 python3.9-dev python3-pip libssl-dev git
 ---> Running in e4289e98ba44

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  binutils binutils-common binutils-x86-64-linux-gnu cpp cpp-9 dpkg-dev
  fakeroot g++ g++-9 gcc gcc-9 gcc-9-base git-man less libalgorithm-diff-perl
  libalgorithm-diff-xs-perl libalgorithm-merge-perl libasan5 libatomic1
  libbinutils libbsd0 libc-dev-bin libc6-dev libcbor0.6 libcc1-0 libcrypt-dev
  libctf-nobfd0 libctf0 libcurl3-gnutls libdpkg-perl libedit2 liberror-perl
  libexpat1-dev libfakeroot libfido2-1 libfile-fcntllock-perl libgcc-9-dev
  libgdbm-compat4 libgdbm6 libgomp1 libisl22 libitm1 liblocale-gettext-perl
  liblsan0 libmpc3 libmpfr6 libnghttp2-14 libperl5.30 libpython3-dev
  libpython3.8 libpython3.8-dev libpython3.9 libpython3.9-dev
  libpython3.9-minimal libpython3.9-stdlib libquadmath0 librtmp1 libssh-4
  libstdc++-9-dev libtsan0 libubsan1 libx11-6 libx11-data libxau6 libxcb1
  libxdmcp6 libxext6 libxmuu1 linux-libc-dev make manpages manpages-dev
  netbase openssh-client patch perl perl-modules-5.30 python-pip-whl
  python3-dev python3-distutils python3-lib2to3 python3-setuptools
  python3-wheel python3.8-dev python3.9-minimal xauth zlib1g-dev
Suggested packages:
  binutils-doc cpp-doc gcc-9-locales debian-keyring g++-multilib
  g++-9-multilib gcc-9-doc gcc-multilib autoconf automake libtool flex bison
  gdb gcc-doc gcc-9-multilib gettext-base git-daemon-run | git-daemon-sysvinit
  git-doc git-el git-email git-gui gitk gitweb git-cvs git-mediawiki git-svn
  glibc-doc bzr gdbm-l10n libssl-doc libstdc++-9-doc make-doc man-browser
  keychain libpam-ssh monkeysphere ssh-askpass ed diffutils-doc perl-doc
  libterm-readline-gnu-perl | libterm-readline-perl-perl libb-debug-perl
  liblocale-codes-perl python-setuptools-doc python3.9-venv python3.9-doc
  binfmt-support
The following NEW packages will be installed:
  binutils binutils-common binutils-x86-64-linux-gnu build-essential cpp cpp-9
  dpkg-dev fakeroot g++ g++-9 gcc gcc-9 gcc-9-base git git-man less
  libalgorithm-diff-perl libalgorithm-diff-xs-perl libalgorithm-merge-perl
  libasan5 libatomic1 libbinutils libbsd0 libc-dev-bin libc6-dev libcbor0.6
  libcc1-0 libcrypt-dev libctf-nobfd0 libctf0 libcurl3-gnutls libdpkg-perl
  libedit2 liberror-perl libexpat1-dev libfakeroot libfido2-1
  libfile-fcntllock-perl libgcc-9-dev libgdbm-compat4 libgdbm6 libgomp1
  libisl22 libitm1 liblocale-gettext-perl liblsan0 libmpc3 libmpfr6
  libnghttp2-14 libperl5.30 libpython3-dev libpython3.8 libpython3.8-dev
  libpython3.9 libpython3.9-dev libpython3.9-minimal libpython3.9-stdlib
  libquadmath0 librtmp1 libssh-4 libssl-dev libstdc++-9-dev libtsan0 libubsan1
  libx11-6 libx11-data libxau6 libxcb1 libxdmcp6 libxext6 libxmuu1
  linux-libc-dev make manpages manpages-dev netbase openssh-client patch perl
  perl-modules-5.30 python-pip-whl python3-dev python3-distutils
  python3-lib2to3 python3-pip python3-setuptools python3-wheel python3.8-dev
  python3.9 python3.9-dev python3.9-minimal xauth zlib1g-dev
0 upgraded, 93 newly installed, 0 to remove and 0 not upgraded.
Need to get 78.5 MB of archives.
After this operation, 363 MB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu focal/main amd64 liblocale-gettext-perl amd64 1.07-4 [17.1 kB]
Get:2 http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal/main amd64 libpython3.9-minimal amd64 3.9.2-1+focal2 [786 kB]
Get:3 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 perl-modules-5.30 all 5.30.0-9ubuntu0.2 [2738 kB]
Get:4 http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal/main amd64 python3.9-minimal amd64 3.9.2-1+focal2 [1890 kB]
Get:5 http://archive.ubuntu.com/ubuntu focal/main amd64 libgdbm6 amd64 1.18.1-5 [27.4 kB]
Get:6 http://archive.ubuntu.com/ubuntu focal/main amd64 libgdbm-compat4 amd64 1.18.1-5 [6244 B]
Get:7 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libperl5.30 amd64 5.30.0-9ubuntu0.2 [3952 kB]
Get:8 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 perl amd64 5.30.0-9ubuntu0.2 [224 kB]
Get:9 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 less amd64 551-1ubuntu0.1 [123 kB]
Get:10 http://archive.ubuntu.com/ubuntu focal/main amd64 libbsd0 amd64 0.10.0-1 [45.4 kB]
Get:11 http://archive.ubuntu.com/ubuntu focal/main amd64 netbase all 6.1 [13.1 kB]
Get:12 http://archive.ubuntu.com/ubuntu focal/main amd64 libcbor0.6 amd64 0.6.0-0ubuntu1 [21.1 kB]
Get:13 http://archive.ubuntu.com/ubuntu focal/main amd64 libedit2 amd64 3.1-20191231-1 [87.0 kB]
Get:14 http://archive.ubuntu.com/ubuntu focal/main amd64 libfido2-1 amd64 1.3.1-1ubuntu2 [47.9 kB]
Get:15 http://archive.ubuntu.com/ubuntu focal/main amd64 libxau6 amd64 1:1.0.9-0ubuntu1 [7488 B]
Get:16 http://archive.ubuntu.com/ubuntu focal/main amd64 libxdmcp6 amd64 1:1.1.3-0ubuntu1 [10.6 kB]
Get:17 http://archive.ubuntu.com/ubuntu focal/main amd64 libxcb1 amd64 1.14-2 [44.7 kB]
Get:18 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libx11-data all 2:1.6.9-2ubuntu1.1 [113 kB]
Get:19 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libx11-6 amd64 2:1.6.9-2ubuntu1.1 [574 kB]
Get:20 http://archive.ubuntu.com/ubuntu focal/main amd64 libxext6 amd64 2:1.3.4-0ubuntu1 [29.1 kB]
Get:21 http://archive.ubuntu.com/ubuntu focal/main amd64 libxmuu1 amd64 2:1.1.3-0ubuntu1 [9728 B]
Get:22 http://archive.ubuntu.com/ubuntu focal/main amd64 manpages all 5.05-1 [1314 kB]
Get:23 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 openssh-client amd64 1:8.2p1-4ubuntu0.1 [672 kB]
Get:24 http://archive.ubuntu.com/ubuntu focal/main amd64 xauth amd64 1:1.1-0ubuntu1 [25.0 kB]
Get:25 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 binutils-common amd64 2.34-6ubuntu1.1 [207 kB]
Get:26 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libbinutils amd64 2.34-6ubuntu1.1 [475 kB]
Get:27 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libctf-nobfd0 amd64 2.34-6ubuntu1.1 [47.1 kB]
Get:28 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libctf0 amd64 2.34-6ubuntu1.1 [46.6 kB]
Get:29 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 binutils-x86-64-linux-gnu amd64 2.34-6ubuntu1.1 [1613 kB]
Get:30 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 binutils amd64 2.34-6ubuntu1.1 [3380 B]
Get:31 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libc-dev-bin amd64 2.31-0ubuntu9.2 [71.8 kB]
Get:32 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-libc-dev amd64 5.4.0-66.74 [1139 kB]
Get:33 http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal/main amd64 libpython3.9-stdlib amd64 3.9.2-1+focal2 [1686 kB]
Get:34 http://archive.ubuntu.com/ubuntu focal/main amd64 libcrypt-dev amd64 1:4.4.10-10ubuntu4 [104 kB]
Get:35 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libc6-dev amd64 2.31-0ubuntu9.2 [2520 kB]
Get:36 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 gcc-9-base amd64 9.3.0-17ubuntu1~20.04 [19.1 kB]
Get:37 http://archive.ubuntu.com/ubuntu focal/main amd64 libisl22 amd64 0.22.1-1 [592 kB]
Get:38 http://archive.ubuntu.com/ubuntu focal/main amd64 libmpfr6 amd64 4.0.2-1 [240 kB]
Get:39 http://archive.ubuntu.com/ubuntu focal/main amd64 libmpc3 amd64 1.1.0-1 [40.8 kB]
Get:40 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 cpp-9 amd64 9.3.0-17ubuntu1~20.04 [7494 kB]
Get:41 http://archive.ubuntu.com/ubuntu focal/main amd64 cpp amd64 4:9.3.0-1ubuntu2 [27.6 kB]
Get:42 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libcc1-0 amd64 10.2.0-5ubuntu1~20.04 [41.1 kB]
Get:43 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libgomp1 amd64 10.2.0-5ubuntu1~20.04 [102 kB]
Get:44 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libitm1 amd64 10.2.0-5ubuntu1~20.04 [26.4 kB]
Get:45 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libatomic1 amd64 10.2.0-5ubuntu1~20.04 [9300 B]
Get:46 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libasan5 amd64 9.3.0-17ubuntu1~20.04 [394 kB]
Get:47 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 liblsan0 amd64 10.2.0-5ubuntu1~20.04 [144 kB]
Get:48 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libtsan0 amd64 10.2.0-5ubuntu1~20.04 [320 kB]
Get:49 http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal/main amd64 libpython3.9 amd64 3.9.2-1+focal2 [1871 kB]
Get:50 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libubsan1 amd64 10.2.0-5ubuntu1~20.04 [136 kB]
Get:51 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libquadmath0 amd64 10.2.0-5ubuntu1~20.04 [146 kB]
Get:52 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libgcc-9-dev amd64 9.3.0-17ubuntu1~20.04 [2360 kB]
Get:53 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 gcc-9 amd64 9.3.0-17ubuntu1~20.04 [8241 kB]
Get:54 http://archive.ubuntu.com/ubuntu focal/main amd64 gcc amd64 4:9.3.0-1ubuntu2 [5208 B]
Get:55 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libstdc++-9-dev amd64 9.3.0-17ubuntu1~20.04 [1714 kB]
Get:56 http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal/main amd64 libpython3.9-dev amd64 3.9.2-1+focal2 [4364 kB]
Get:57 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 g++-9 amd64 9.3.0-17ubuntu1~20.04 [8405 kB]
Get:58 http://archive.ubuntu.com/ubuntu focal/main amd64 g++ amd64 4:9.3.0-1ubuntu2 [1604 B]
Get:59 http://archive.ubuntu.com/ubuntu focal/main amd64 make amd64 4.2.1-1.2 [162 kB]
Get:60 http://archive.ubuntu.com/ubuntu focal/main amd64 libdpkg-perl all 1.19.7ubuntu3 [230 kB]
Get:61 http://archive.ubuntu.com/ubuntu focal/main amd64 patch amd64 2.7.6-6 [105 kB]
Get:62 http://archive.ubuntu.com/ubuntu focal/main amd64 dpkg-dev all 1.19.7ubuntu3 [679 kB]
Get:63 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 build-essential amd64 12.8ubuntu1.1 [4664 B]
Get:64 http://archive.ubuntu.com/ubuntu focal/main amd64 libfakeroot amd64 1.24-1 [25.7 kB]
Get:65 http://archive.ubuntu.com/ubuntu focal/main amd64 fakeroot amd64 1.24-1 [62.6 kB]
Get:66 http://archive.ubuntu.com/ubuntu focal/main amd64 libnghttp2-14 amd64 1.40.0-1build1 [78.7 kB]
Get:67 http://archive.ubuntu.com/ubuntu focal/main amd64 librtmp1 amd64 2.4+20151223.gitfa8646d.1-2build1 [54.9 kB]
Get:68 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libssh-4 amd64 0.9.3-2ubuntu2.1 [170 kB]
Get:69 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libcurl3-gnutls amd64 7.68.0-1ubuntu2.4 [231 kB]
Get:70 http://archive.ubuntu.com/ubuntu focal/main amd64 liberror-perl all 0.17029-1 [26.5 kB]
Get:71 http://archive.ubuntu.com/ubuntu focal/main amd64 git-man all 1:2.25.1-1ubuntu3 [884 kB]
Get:72 http://archive.ubuntu.com/ubuntu focal/main amd64 git amd64 1:2.25.1-1ubuntu3 [4554 kB]
Get:73 http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal/main amd64 python3.9 amd64 3.9.2-1+focal2 [464 kB]
Get:74 http://archive.ubuntu.com/ubuntu focal/main amd64 libalgorithm-diff-perl all 1.19.03-2 [46.6 kB]
Get:75 http://archive.ubuntu.com/ubuntu focal/main amd64 libalgorithm-diff-xs-perl amd64 0.04-6 [11.3 kB]
Get:76 http://archive.ubuntu.com/ubuntu focal/main amd64 libalgorithm-merge-perl all 0.08-3 [12.0 kB]
Get:77 http://archive.ubuntu.com/ubuntu focal/main amd64 libexpat1-dev amd64 2.2.9-1build1 [116 kB]
Get:78 http://archive.ubuntu.com/ubuntu focal/main amd64 libfile-fcntllock-perl amd64 0.22-3build4 [33.1 kB]
Get:79 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libpython3.8 amd64 3.8.5-1~20.04.2 [1624 kB]
Get:80 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libpython3.8-dev amd64 3.8.5-1~20.04.2 [3942 kB]
Get:81 http://archive.ubuntu.com/ubuntu focal/main amd64 libpython3-dev amd64 3.8.2-0ubuntu2 [7236 B]
Get:82 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libssl-dev amd64 1.1.1f-1ubuntu2.2 [1582 kB]
Get:83 http://archive.ubuntu.com/ubuntu focal/main amd64 manpages-dev all 5.05-1 [2266 kB]
Get:84 http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal/main amd64 python3.9-dev amd64 3.9.2-1+focal2 [501 kB]
Get:85 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 python-pip-whl all 20.0.2-5ubuntu1.1 [1799 kB]
Get:86 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 zlib1g-dev amd64 1:1.2.11.dfsg-2ubuntu1.2 [155 kB]
Get:87 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 python3.8-dev amd64 3.8.5-1~20.04.2 [515 kB]
Get:88 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 python3-lib2to3 all 3.8.5-1~20.04.1 [75.6 kB]
Get:89 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 python3-distutils all 3.8.5-1~20.04.1 [141 kB]
Get:90 http://archive.ubuntu.com/ubuntu focal/main amd64 python3-dev amd64 3.8.2-0ubuntu2 [1212 B]
Get:91 http://archive.ubuntu.com/ubuntu focal/main amd64 python3-setuptools all 45.2.0-1 [330 kB]
Get:92 http://archive.ubuntu.com/ubuntu focal/universe amd64 python3-wheel all 0.34.2-1 [23.8 kB]
Get:93 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 python3-pip all 20.0.2-5ubuntu1.1 [230 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 78.5 MB in 12s (6408 kB/s)
Selecting previously unselected package liblocale-gettext-perl.
(Reading database ... 10773 files and directories currently installed.)
Preparing to unpack .../00-liblocale-gettext-perl_1.07-4_amd64.deb ...
Unpacking liblocale-gettext-perl (1.07-4) ...
Selecting previously unselected package perl-modules-5.30.
Preparing to unpack .../01-perl-modules-5.30_5.30.0-9ubuntu0.2_all.deb ...
Unpacking perl-modules-5.30 (5.30.0-9ubuntu0.2) ...
Selecting previously unselected package libgdbm6:amd64.
Preparing to unpack .../02-libgdbm6_1.18.1-5_amd64.deb ...
Unpacking libgdbm6:amd64 (1.18.1-5) ...
Selecting previously unselected package libgdbm-compat4:amd64.
Preparing to unpack .../03-libgdbm-compat4_1.18.1-5_amd64.deb ...
Unpacking libgdbm-compat4:amd64 (1.18.1-5) ...
Selecting previously unselected package libperl5.30:amd64.
Preparing to unpack .../04-libperl5.30_5.30.0-9ubuntu0.2_amd64.deb ...
Unpacking libperl5.30:amd64 (5.30.0-9ubuntu0.2) ...
Selecting previously unselected package perl.
Preparing to unpack .../05-perl_5.30.0-9ubuntu0.2_amd64.deb ...
Unpacking perl (5.30.0-9ubuntu0.2) ...
Selecting previously unselected package libpython3.9-minimal:amd64.
Preparing to unpack .../06-libpython3.9-minimal_3.9.2-1+focal2_amd64.deb ...
Unpacking libpython3.9-minimal:amd64 (3.9.2-1+focal2) ...
Selecting previously unselected package python3.9-minimal.
Preparing to unpack .../07-python3.9-minimal_3.9.2-1+focal2_amd64.deb ...
Unpacking python3.9-minimal (3.9.2-1+focal2) ...
Selecting previously unselected package less.
Preparing to unpack .../08-less_551-1ubuntu0.1_amd64.deb ...
Unpacking less (551-1ubuntu0.1) ...
Selecting previously unselected package libbsd0:amd64.
Preparing to unpack .../09-libbsd0_0.10.0-1_amd64.deb ...
Unpacking libbsd0:amd64 (0.10.0-1) ...
Selecting previously unselected package netbase.
Preparing to unpack .../10-netbase_6.1_all.deb ...
Unpacking netbase (6.1) ...
Selecting previously unselected package libcbor0.6:amd64.
Preparing to unpack .../11-libcbor0.6_0.6.0-0ubuntu1_amd64.deb ...
Unpacking libcbor0.6:amd64 (0.6.0-0ubuntu1) ...
Selecting previously unselected package libedit2:amd64.
Preparing to unpack .../12-libedit2_3.1-20191231-1_amd64.deb ...
Unpacking libedit2:amd64 (3.1-20191231-1) ...
Selecting previously unselected package libfido2-1:amd64.
Preparing to unpack .../13-libfido2-1_1.3.1-1ubuntu2_amd64.deb ...
Unpacking libfido2-1:amd64 (1.3.1-1ubuntu2) ...
Selecting previously unselected package libxau6:amd64.
Preparing to unpack .../14-libxau6_1%3a1.0.9-0ubuntu1_amd64.deb ...
Unpacking libxau6:amd64 (1:1.0.9-0ubuntu1) ...
Selecting previously unselected package libxdmcp6:amd64.
Preparing to unpack .../15-libxdmcp6_1%3a1.1.3-0ubuntu1_amd64.deb ...
Unpacking libxdmcp6:amd64 (1:1.1.3-0ubuntu1) ...
Selecting previously unselected package libxcb1:amd64.
Preparing to unpack .../16-libxcb1_1.14-2_amd64.deb ...
Unpacking libxcb1:amd64 (1.14-2) ...
Selecting previously unselected package libx11-data.
Preparing to unpack .../17-libx11-data_2%3a1.6.9-2ubuntu1.1_all.deb ...
Unpacking libx11-data (2:1.6.9-2ubuntu1.1) ...
Selecting previously unselected package libx11-6:amd64.
Preparing to unpack .../18-libx11-6_2%3a1.6.9-2ubuntu1.1_amd64.deb ...
Unpacking libx11-6:amd64 (2:1.6.9-2ubuntu1.1) ...
Selecting previously unselected package libxext6:amd64.
Preparing to unpack .../19-libxext6_2%3a1.3.4-0ubuntu1_amd64.deb ...
Unpacking libxext6:amd64 (2:1.3.4-0ubuntu1) ...
Selecting previously unselected package libxmuu1:amd64.
Preparing to unpack .../20-libxmuu1_2%3a1.1.3-0ubuntu1_amd64.deb ...
Unpacking libxmuu1:amd64 (2:1.1.3-0ubuntu1) ...
Selecting previously unselected package manpages.
Preparing to unpack .../21-manpages_5.05-1_all.deb ...
Unpacking manpages (5.05-1) ...
Selecting previously unselected package openssh-client.
Preparing to unpack .../22-openssh-client_1%3a8.2p1-4ubuntu0.1_amd64.deb ...
Unpacking openssh-client (1:8.2p1-4ubuntu0.1) ...
Selecting previously unselected package xauth.
Preparing to unpack .../23-xauth_1%3a1.1-0ubuntu1_amd64.deb ...
Unpacking xauth (1:1.1-0ubuntu1) ...
Selecting previously unselected package binutils-common:amd64.
Preparing to unpack .../24-binutils-common_2.34-6ubuntu1.1_amd64.deb ...
Unpacking binutils-common:amd64 (2.34-6ubuntu1.1) ...
Selecting previously unselected package libbinutils:amd64.
Preparing to unpack .../25-libbinutils_2.34-6ubuntu1.1_amd64.deb ...
Unpacking libbinutils:amd64 (2.34-6ubuntu1.1) ...
Selecting previously unselected package libctf-nobfd0:amd64.
Preparing to unpack .../26-libctf-nobfd0_2.34-6ubuntu1.1_amd64.deb ...
Unpacking libctf-nobfd0:amd64 (2.34-6ubuntu1.1) ...
Selecting previously unselected package libctf0:amd64.
Preparing to unpack .../27-libctf0_2.34-6ubuntu1.1_amd64.deb ...
Unpacking libctf0:amd64 (2.34-6ubuntu1.1) ...
Selecting previously unselected package binutils-x86-64-linux-gnu.
Preparing to unpack .../28-binutils-x86-64-linux-gnu_2.34-6ubuntu1.1_amd64.deb ...
Unpacking binutils-x86-64-linux-gnu (2.34-6ubuntu1.1) ...
Selecting previously unselected package binutils.
Preparing to unpack .../29-binutils_2.34-6ubuntu1.1_amd64.deb ...
Unpacking binutils (2.34-6ubuntu1.1) ...
Selecting previously unselected package libc-dev-bin.
Preparing to unpack .../30-libc-dev-bin_2.31-0ubuntu9.2_amd64.deb ...
Unpacking libc-dev-bin (2.31-0ubuntu9.2) ...
Selecting previously unselected package linux-libc-dev:amd64.
Preparing to unpack .../31-linux-libc-dev_5.4.0-66.74_amd64.deb ...
Unpacking linux-libc-dev:amd64 (5.4.0-66.74) ...
Selecting previously unselected package libcrypt-dev:amd64.
Preparing to unpack .../32-libcrypt-dev_1%3a4.4.10-10ubuntu4_amd64.deb ...
Unpacking libcrypt-dev:amd64 (1:4.4.10-10ubuntu4) ...
Selecting previously unselected package libc6-dev:amd64.
Preparing to unpack .../33-libc6-dev_2.31-0ubuntu9.2_amd64.deb ...
Unpacking libc6-dev:amd64 (2.31-0ubuntu9.2) ...
Selecting previously unselected package gcc-9-base:amd64.
Preparing to unpack .../34-gcc-9-base_9.3.0-17ubuntu1~20.04_amd64.deb ...
Unpacking gcc-9-base:amd64 (9.3.0-17ubuntu1~20.04) ...
Selecting previously unselected package libisl22:amd64.
Preparing to unpack .../35-libisl22_0.22.1-1_amd64.deb ...
Unpacking libisl22:amd64 (0.22.1-1) ...
Selecting previously unselected package libmpfr6:amd64.
Preparing to unpack .../36-libmpfr6_4.0.2-1_amd64.deb ...
Unpacking libmpfr6:amd64 (4.0.2-1) ...
Selecting previously unselected package libmpc3:amd64.
Preparing to unpack .../37-libmpc3_1.1.0-1_amd64.deb ...
Unpacking libmpc3:amd64 (1.1.0-1) ...
Selecting previously unselected package cpp-9.
Preparing to unpack .../38-cpp-9_9.3.0-17ubuntu1~20.04_amd64.deb ...
Unpacking cpp-9 (9.3.0-17ubuntu1~20.04) ...
Selecting previously unselected package cpp.
Preparing to unpack .../39-cpp_4%3a9.3.0-1ubuntu2_amd64.deb ...
Unpacking cpp (4:9.3.0-1ubuntu2) ...
Selecting previously unselected package libcc1-0:amd64.
Preparing to unpack .../40-libcc1-0_10.2.0-5ubuntu1~20.04_amd64.deb ...
Unpacking libcc1-0:amd64 (10.2.0-5ubuntu1~20.04) ...
Selecting previously unselected package libgomp1:amd64.
Preparing to unpack .../41-libgomp1_10.2.0-5ubuntu1~20.04_amd64.deb ...
Unpacking libgomp1:amd64 (10.2.0-5ubuntu1~20.04) ...
Selecting previously unselected package libitm1:amd64.
Preparing to unpack .../42-libitm1_10.2.0-5ubuntu1~20.04_amd64.deb ...
Unpacking libitm1:amd64 (10.2.0-5ubuntu1~20.04) ...
Selecting previously unselected package libatomic1:amd64.
Preparing to unpack .../43-libatomic1_10.2.0-5ubuntu1~20.04_amd64.deb ...
Unpacking libatomic1:amd64 (10.2.0-5ubuntu1~20.04) ...
Selecting previously unselected package libasan5:amd64.
Preparing to unpack .../44-libasan5_9.3.0-17ubuntu1~20.04_amd64.deb ...
Unpacking libasan5:amd64 (9.3.0-17ubuntu1~20.04) ...
Selecting previously unselected package liblsan0:amd64.
Preparing to unpack .../45-liblsan0_10.2.0-5ubuntu1~20.04_amd64.deb ...
Unpacking liblsan0:amd64 (10.2.0-5ubuntu1~20.04) ...
Selecting previously unselected package libtsan0:amd64.
Preparing to unpack .../46-libtsan0_10.2.0-5ubuntu1~20.04_amd64.deb ...
Unpacking libtsan0:amd64 (10.2.0-5ubuntu1~20.04) ...
Selecting previously unselected package libubsan1:amd64.
Preparing to unpack .../47-libubsan1_10.2.0-5ubuntu1~20.04_amd64.deb ...
Unpacking libubsan1:amd64 (10.2.0-5ubuntu1~20.04) ...
Selecting previously unselected package libquadmath0:amd64.
Preparing to unpack .../48-libquadmath0_10.2.0-5ubuntu1~20.04_amd64.deb ...
Unpacking libquadmath0:amd64 (10.2.0-5ubuntu1~20.04) ...
Selecting previously unselected package libgcc-9-dev:amd64.
Preparing to unpack .../49-libgcc-9-dev_9.3.0-17ubuntu1~20.04_amd64.deb ...
Unpacking libgcc-9-dev:amd64 (9.3.0-17ubuntu1~20.04) ...
Selecting previously unselected package gcc-9.
Preparing to unpack .../50-gcc-9_9.3.0-17ubuntu1~20.04_amd64.deb ...
Unpacking gcc-9 (9.3.0-17ubuntu1~20.04) ...
Selecting previously unselected package gcc.
Preparing to unpack .../51-gcc_4%3a9.3.0-1ubuntu2_amd64.deb ...
Unpacking gcc (4:9.3.0-1ubuntu2) ...
Selecting previously unselected package libstdc++-9-dev:amd64.
Preparing to unpack .../52-libstdc++-9-dev_9.3.0-17ubuntu1~20.04_amd64.deb ...
Unpacking libstdc++-9-dev:amd64 (9.3.0-17ubuntu1~20.04) ...
Selecting previously unselected package g++-9.
Preparing to unpack .../53-g++-9_9.3.0-17ubuntu1~20.04_amd64.deb ...
Unpacking g++-9 (9.3.0-17ubuntu1~20.04) ...
Selecting previously unselected package g++.
Preparing to unpack .../54-g++_4%3a9.3.0-1ubuntu2_amd64.deb ...
Unpacking g++ (4:9.3.0-1ubuntu2) ...
Selecting previously unselected package make.
Preparing to unpack .../55-make_4.2.1-1.2_amd64.deb ...
Unpacking make (4.2.1-1.2) ...
Selecting previously unselected package libdpkg-perl.
Preparing to unpack .../56-libdpkg-perl_1.19.7ubuntu3_all.deb ...
Unpacking libdpkg-perl (1.19.7ubuntu3) ...
Selecting previously unselected package patch.
Preparing to unpack .../57-patch_2.7.6-6_amd64.deb ...
Unpacking patch (2.7.6-6) ...
Selecting previously unselected package dpkg-dev.
Preparing to unpack .../58-dpkg-dev_1.19.7ubuntu3_all.deb ...
Unpacking dpkg-dev (1.19.7ubuntu3) ...
Selecting previously unselected package build-essential.
Preparing to unpack .../59-build-essential_12.8ubuntu1.1_amd64.deb ...
Unpacking build-essential (12.8ubuntu1.1) ...
Selecting previously unselected package libfakeroot:amd64.
Preparing to unpack .../60-libfakeroot_1.24-1_amd64.deb ...
Unpacking libfakeroot:amd64 (1.24-1) ...
Selecting previously unselected package fakeroot.
Preparing to unpack .../61-fakeroot_1.24-1_amd64.deb ...
Unpacking fakeroot (1.24-1) ...
Selecting previously unselected package libnghttp2-14:amd64.
Preparing to unpack .../62-libnghttp2-14_1.40.0-1build1_amd64.deb ...
Unpacking libnghttp2-14:amd64 (1.40.0-1build1) ...
Selecting previously unselected package librtmp1:amd64.
Preparing to unpack .../63-librtmp1_2.4+20151223.gitfa8646d.1-2build1_amd64.deb ...
Unpacking librtmp1:amd64 (2.4+20151223.gitfa8646d.1-2build1) ...
Selecting previously unselected package libssh-4:amd64.
Preparing to unpack .../64-libssh-4_0.9.3-2ubuntu2.1_amd64.deb ...
Unpacking libssh-4:amd64 (0.9.3-2ubuntu2.1) ...
Selecting previously unselected package libcurl3-gnutls:amd64.
Preparing to unpack .../65-libcurl3-gnutls_7.68.0-1ubuntu2.4_amd64.deb ...
Unpacking libcurl3-gnutls:amd64 (7.68.0-1ubuntu2.4) ...
Selecting previously unselected package liberror-perl.
Preparing to unpack .../66-liberror-perl_0.17029-1_all.deb ...
Unpacking liberror-perl (0.17029-1) ...
Selecting previously unselected package git-man.
Preparing to unpack .../67-git-man_1%3a2.25.1-1ubuntu3_all.deb ...
Unpacking git-man (1:2.25.1-1ubuntu3) ...
Selecting previously unselected package git.
Preparing to unpack .../68-git_1%3a2.25.1-1ubuntu3_amd64.deb ...
Unpacking git (1:2.25.1-1ubuntu3) ...
Selecting previously unselected package libalgorithm-diff-perl.
Preparing to unpack .../69-libalgorithm-diff-perl_1.19.03-2_all.deb ...
Unpacking libalgorithm-diff-perl (1.19.03-2) ...
Selecting previously unselected package libalgorithm-diff-xs-perl.
Preparing to unpack .../70-libalgorithm-diff-xs-perl_0.04-6_amd64.deb ...
Unpacking libalgorithm-diff-xs-perl (0.04-6) ...
Selecting previously unselected package libalgorithm-merge-perl.
Preparing to unpack .../71-libalgorithm-merge-perl_0.08-3_all.deb ...
Unpacking libalgorithm-merge-perl (0.08-3) ...
Selecting previously unselected package libexpat1-dev:amd64.
Preparing to unpack .../72-libexpat1-dev_2.2.9-1build1_amd64.deb ...
Unpacking libexpat1-dev:amd64 (2.2.9-1build1) ...
Selecting previously unselected package libfile-fcntllock-perl.
Preparing to unpack .../73-libfile-fcntllock-perl_0.22-3build4_amd64.deb ...
Unpacking libfile-fcntllock-perl (0.22-3build4) ...
Selecting previously unselected package libpython3.8:amd64.
Preparing to unpack .../74-libpython3.8_3.8.5-1~20.04.2_amd64.deb ...
Unpacking libpython3.8:amd64 (3.8.5-1~20.04.2) ...
Selecting previously unselected package libpython3.8-dev:amd64.
Preparing to unpack .../75-libpython3.8-dev_3.8.5-1~20.04.2_amd64.deb ...
Unpacking libpython3.8-dev:amd64 (3.8.5-1~20.04.2) ...
Selecting previously unselected package libpython3-dev:amd64.
Preparing to unpack .../76-libpython3-dev_3.8.2-0ubuntu2_amd64.deb ...
Unpacking libpython3-dev:amd64 (3.8.2-0ubuntu2) ...
Selecting previously unselected package libpython3.9-stdlib:amd64.
Preparing to unpack .../77-libpython3.9-stdlib_3.9.2-1+focal2_amd64.deb ...
Unpacking libpython3.9-stdlib:amd64 (3.9.2-1+focal2) ...
Selecting previously unselected package libpython3.9:amd64.
Preparing to unpack .../78-libpython3.9_3.9.2-1+focal2_amd64.deb ...
Unpacking libpython3.9:amd64 (3.9.2-1+focal2) ...
Selecting previously unselected package libpython3.9-dev:amd64.
Preparing to unpack .../79-libpython3.9-dev_3.9.2-1+focal2_amd64.deb ...
Unpacking libpython3.9-dev:amd64 (3.9.2-1+focal2) ...
Selecting previously unselected package libssl-dev:amd64.
Preparing to unpack .../80-libssl-dev_1.1.1f-1ubuntu2.2_amd64.deb ...
Unpacking libssl-dev:amd64 (1.1.1f-1ubuntu2.2) ...
Selecting previously unselected package manpages-dev.
Preparing to unpack .../81-manpages-dev_5.05-1_all.deb ...
Unpacking manpages-dev (5.05-1) ...
Selecting previously unselected package python-pip-whl.
Preparing to unpack .../82-python-pip-whl_20.0.2-5ubuntu1.1_all.deb ...
Unpacking python-pip-whl (20.0.2-5ubuntu1.1) ...
Selecting previously unselected package zlib1g-dev:amd64.
Preparing to unpack .../83-zlib1g-dev_1%3a1.2.11.dfsg-2ubuntu1.2_amd64.deb ...
Unpacking zlib1g-dev:amd64 (1:1.2.11.dfsg-2ubuntu1.2) ...
Selecting previously unselected package python3.8-dev.
Preparing to unpack .../84-python3.8-dev_3.8.5-1~20.04.2_amd64.deb ...
Unpacking python3.8-dev (3.8.5-1~20.04.2) ...
Selecting previously unselected package python3-lib2to3.
Preparing to unpack .../85-python3-lib2to3_3.8.5-1~20.04.1_all.deb ...
Unpacking python3-lib2to3 (3.8.5-1~20.04.1) ...
Selecting previously unselected package python3-distutils.
Preparing to unpack .../86-python3-distutils_3.8.5-1~20.04.1_all.deb ...
Unpacking python3-distutils (3.8.5-1~20.04.1) ...
Selecting previously unselected package python3-dev.
Preparing to unpack .../87-python3-dev_3.8.2-0ubuntu2_amd64.deb ...
Unpacking python3-dev (3.8.2-0ubuntu2) ...
Selecting previously unselected package python3-setuptools.
Preparing to unpack .../88-python3-setuptools_45.2.0-1_all.deb ...
Unpacking python3-setuptools (45.2.0-1) ...
Selecting previously unselected package python3-wheel.
Preparing to unpack .../89-python3-wheel_0.34.2-1_all.deb ...
Unpacking python3-wheel (0.34.2-1) ...
Selecting previously unselected package python3-pip.
Preparing to unpack .../90-python3-pip_20.0.2-5ubuntu1.1_all.deb ...
Unpacking python3-pip (20.0.2-5ubuntu1.1) ...
Selecting previously unselected package python3.9.
Preparing to unpack .../91-python3.9_3.9.2-1+focal2_amd64.deb ...
Unpacking python3.9 (3.9.2-1+focal2) ...
Selecting previously unselected package python3.9-dev.
Preparing to unpack .../92-python3.9-dev_3.9.2-1+focal2_amd64.deb ...
Unpacking python3.9-dev (3.9.2-1+focal2) ...
Setting up libxau6:amd64 (1:1.0.9-0ubuntu1) ...
Setting up perl-modules-5.30 (5.30.0-9ubuntu0.2) ...
Setting up libpython3.9-minimal:amd64 (3.9.2-1+focal2) ...
Setting up manpages (5.05-1) ...
Setting up binutils-common:amd64 (2.34-6ubuntu1.1) ...
Setting up libnghttp2-14:amd64 (1.40.0-1build1) ...
Setting up less (551-1ubuntu0.1) ...
Setting up linux-libc-dev:amd64 (5.4.0-66.74) ...
Setting up libctf-nobfd0:amd64 (2.34-6ubuntu1.1) ...
Setting up libgomp1:amd64 (10.2.0-5ubuntu1~20.04) ...
Setting up libcbor0.6:amd64 (0.6.0-0ubuntu1) ...
Setting up python3-wheel (0.34.2-1) ...
Setting up libfakeroot:amd64 (1.24-1) ...
Setting up fakeroot (1.24-1) ...
update-alternatives: using /usr/bin/fakeroot-sysv to provide /usr/bin/fakeroot (fakeroot) in auto mode
update-alternatives: warning: skip creation of /usr/share/man/man1/fakeroot.1.gz because associated file /usr/share/man/man1/fakeroot-sysv.1.gz (of link group fakeroot) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/faked.1.gz because associated file /usr/share/man/man1/faked-sysv.1.gz (of link group fakeroot) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/es/man1/fakeroot.1.gz because associated file /usr/share/man/es/man1/fakeroot-sysv.1.gz (of link group fakeroot) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/es/man1/faked.1.gz because associated file /usr/share/man/es/man1/faked-sysv.1.gz (of link group fakeroot) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/fr/man1/fakeroot.1.gz because associated file /usr/share/man/fr/man1/fakeroot-sysv.1.gz (of link group fakeroot) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/fr/man1/faked.1.gz because associated file /usr/share/man/fr/man1/faked-sysv.1.gz (of link group fakeroot) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/sv/man1/fakeroot.1.gz because associated file /usr/share/man/sv/man1/fakeroot-sysv.1.gz (of link group fakeroot) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/sv/man1/faked.1.gz because associated file /usr/share/man/sv/man1/faked-sysv.1.gz (of link group fakeroot) doesn't exist
Setting up libx11-data (2:1.6.9-2ubuntu1.1) ...
Setting up make (4.2.1-1.2) ...
Setting up libmpfr6:amd64 (4.0.2-1) ...
Setting up librtmp1:amd64 (2.4+20151223.gitfa8646d.1-2build1) ...
Setting up libpython3.8:amd64 (3.8.5-1~20.04.2) ...
Setting up libquadmath0:amd64 (10.2.0-5ubuntu1~20.04) ...
Setting up libssl-dev:amd64 (1.1.1f-1ubuntu2.2) ...
Setting up libmpc3:amd64 (1.1.0-1) ...
Setting up libatomic1:amd64 (10.2.0-5ubuntu1~20.04) ...
Setting up patch (2.7.6-6) ...
Setting up libssh-4:amd64 (0.9.3-2ubuntu2.1) ...
Setting up libubsan1:amd64 (10.2.0-5ubuntu1~20.04) ...
Setting up libcrypt-dev:amd64 (1:4.4.10-10ubuntu4) ...
Setting up git-man (1:2.25.1-1ubuntu3) ...
Setting up libisl22:amd64 (0.22.1-1) ...
Setting up netbase (6.1) ...
Setting up python-pip-whl (20.0.2-5ubuntu1.1) ...
Setting up python3.9-minimal (3.9.2-1+focal2) ...
Setting up libbinutils:amd64 (2.34-6ubuntu1.1) ...
Setting up libfido2-1:amd64 (1.3.1-1ubuntu2) ...
Setting up libc-dev-bin (2.31-0ubuntu9.2) ...
Setting up libbsd0:amd64 (0.10.0-1) ...
Setting up python3-lib2to3 (3.8.5-1~20.04.1) ...
Setting up libcc1-0:amd64 (10.2.0-5ubuntu1~20.04) ...
Setting up liblocale-gettext-perl (1.07-4) ...
Setting up liblsan0:amd64 (10.2.0-5ubuntu1~20.04) ...
Setting up libitm1:amd64 (10.2.0-5ubuntu1~20.04) ...
Setting up libpython3.9-stdlib:amd64 (3.9.2-1+focal2) ...
Setting up libgdbm6:amd64 (1.18.1-5) ...
Setting up gcc-9-base:amd64 (9.3.0-17ubuntu1~20.04) ...
Setting up libtsan0:amd64 (10.2.0-5ubuntu1~20.04) ...
Setting up libctf0:amd64 (2.34-6ubuntu1.1) ...
Setting up python3-distutils (3.8.5-1~20.04.1) ...
Setting up manpages-dev (5.05-1) ...
Setting up libxdmcp6:amd64 (1:1.1.3-0ubuntu1) ...
Setting up libxcb1:amd64 (1.14-2) ...
Setting up python3-setuptools (45.2.0-1) ...
Setting up libedit2:amd64 (3.1-20191231-1) ...
Setting up libcurl3-gnutls:amd64 (7.68.0-1ubuntu2.4) ...
Setting up libasan5:amd64 (9.3.0-17ubuntu1~20.04) ...
Setting up libpython3.9:amd64 (3.9.2-1+focal2) ...
Setting up libgdbm-compat4:amd64 (1.18.1-5) ...
Setting up python3-pip (20.0.2-5ubuntu1.1) ...
Setting up cpp-9 (9.3.0-17ubuntu1~20.04) ...
Setting up libperl5.30:amd64 (5.30.0-9ubuntu0.2) ...
Setting up libc6-dev:amd64 (2.31-0ubuntu9.2) ...
Setting up libx11-6:amd64 (2:1.6.9-2ubuntu1.1) ...
Setting up libxmuu1:amd64 (2:1.1.3-0ubuntu1) ...
Setting up python3.9 (3.9.2-1+focal2) ...
Setting up binutils-x86-64-linux-gnu (2.34-6ubuntu1.1) ...
Setting up openssh-client (1:8.2p1-4ubuntu0.1) ...
Setting up libxext6:amd64 (2:1.3.4-0ubuntu1) ...
Setting up binutils (2.34-6ubuntu1.1) ...
Setting up libgcc-9-dev:amd64 (9.3.0-17ubuntu1~20.04) ...
Setting up perl (5.30.0-9ubuntu0.2) ...
Setting up libexpat1-dev:amd64 (2.2.9-1build1) ...
Setting up libpython3.8-dev:amd64 (3.8.5-1~20.04.2) ...
Setting up libdpkg-perl (1.19.7ubuntu3) ...
Setting up zlib1g-dev:amd64 (1:1.2.11.dfsg-2ubuntu1.2) ...
Setting up xauth (1:1.1-0ubuntu1) ...
Setting up cpp (4:9.3.0-1ubuntu2) ...
Setting up gcc-9 (9.3.0-17ubuntu1~20.04) ...
Setting up libpython3-dev:amd64 (3.8.2-0ubuntu2) ...
Setting up libstdc++-9-dev:amd64 (9.3.0-17ubuntu1~20.04) ...
Setting up libfile-fcntllock-perl (0.22-3build4) ...
Setting up libalgorithm-diff-perl (1.19.03-2) ...
Setting up libpython3.9-dev:amd64 (3.9.2-1+focal2) ...
Setting up gcc (4:9.3.0-1ubuntu2) ...
Setting up dpkg-dev (1.19.7ubuntu3) ...
Setting up liberror-perl (0.17029-1) ...
Setting up git (1:2.25.1-1ubuntu3) ...
Setting up g++-9 (9.3.0-17ubuntu1~20.04) ...
Setting up python3.8-dev (3.8.5-1~20.04.2) ...
Setting up g++ (4:9.3.0-1ubuntu2) ...
update-alternatives: using /usr/bin/g++ to provide /usr/bin/c++ (c++) in auto mode
update-alternatives: warning: skip creation of /usr/share/man/man1/c++.1.gz because associated file /usr/share/man/man1/g++.1.gz (of link group c++) doesn't exist
Setting up python3.9-dev (3.9.2-1+focal2) ...
Setting up build-essential (12.8ubuntu1.1) ...
Setting up libalgorithm-diff-xs-perl (0.04-6) ...
Setting up libalgorithm-merge-perl (0.08-3) ...
Setting up python3-dev (3.8.2-0ubuntu2) ...
Processing triggers for libc-bin (2.31-0ubuntu9.2) ...
Processing triggers for mime-support (3.64ubuntu1) ...
Removing intermediate container e4289e98ba44
 ---> 204f53cb0122
Step 6/8 : WORKDIR /home/elastalert
 ---> Running in 1e6b90cfe5e8
Removing intermediate container 1e6b90cfe5e8
 ---> 1f6872512d26
Step 7/8 : ADD requirements*.txt ./
 ---> 6ad031b525a4
Step 8/8 : RUN pip3 install -r requirements-dev.txt
 ---> Running in 502237d55900
Collecting apscheduler>=3.3.0
  Downloading APScheduler-3.7.0-py2.py3-none-any.whl (59 kB)
Collecting aws-requests-auth>=0.3.0
  Downloading aws_requests_auth-0.4.3-py2.py3-none-any.whl (6.8 kB)
Collecting sortedcontainers>=2.2.2
  Downloading sortedcontainers-2.3.0-py2.py3-none-any.whl (29 kB)
Collecting boto3>=1.4.4
  Downloading boto3-1.17.18-py2.py3-none-any.whl (130 kB)
Collecting cffi>=1.11.5
  Downloading cffi-1.14.5-cp38-cp38-manylinux1_x86_64.whl (411 kB)
Collecting configparser>=3.5.0
  Downloading configparser-5.0.2-py3-none-any.whl (19 kB)
Collecting croniter>=0.3.16
  Downloading croniter-1.0.6-py2.py3-none-any.whl (13 kB)
Collecting elasticsearch==7.0.0
  Downloading elasticsearch-7.0.0-py2.py3-none-any.whl (80 kB)
Collecting envparse>=0.2.0
  Downloading envparse-0.2.0.tar.gz (7.6 kB)
Collecting exotel>=0.1.3
  Downloading exotel-0.1.5.tar.gz (2.2 kB)
Collecting Jinja2==2.10.1
  Downloading Jinja2-2.10.1-py2.py3-none-any.whl (124 kB)
Collecting jira>=2.0.0
  Downloading jira-2.0.0-py2.py3-none-any.whl (57 kB)
Collecting jsonschema>=3.0.2
  Downloading jsonschema-3.2.0-py2.py3-none-any.whl (56 kB)
Collecting mock>=2.0.0
  Downloading mock-4.0.3-py3-none-any.whl (28 kB)
Collecting prison>=0.1.2
  Downloading prison-0.1.3-py2.py3-none-any.whl (5.8 kB)
Collecting py-zabbix>=1.1.3
  Downloading py_zabbix-1.1.7-py3-none-any.whl (19 kB)
Collecting PyStaticConfiguration>=0.10.3
  Downloading PyStaticConfiguration-0.10.5.tar.gz (21 kB)
Collecting python-dateutil<2.7.0,>=2.6.0
  Downloading python_dateutil-2.6.1-py2.py3-none-any.whl (194 kB)
Collecting PyYAML>=5.1
  Downloading PyYAML-5.4.1-cp38-cp38-manylinux1_x86_64.whl (662 kB)
Requirement already satisfied: requests>=2.10.0 in /usr/lib/python3/dist-packages (from -r requirements.txt (line 20)) (2.22.0)
Collecting stomp.py>=4.1.17
  Downloading stomp.py-6.1.0-py3-none-any.whl (37 kB)
Collecting texttable>=0.8.8
  Downloading texttable-1.6.3-py2.py3-none-any.whl (10 kB)
Collecting twilio<6.1,>=6.0.0
  Downloading twilio-6.0.0.tar.gz (304 kB)
Collecting tzlocal<3.0
  Downloading tzlocal-2.1-py2.py3-none-any.whl (16 kB)
Collecting coverage==5.5
  Downloading coverage-5.5-cp38-cp38-manylinux2010_x86_64.whl (245 kB)
Collecting flake8
  Downloading flake8-3.8.4-py2.py3-none-any.whl (72 kB)
Collecting pluggy>=0.12.0
  Downloading pluggy-0.13.1-py2.py3-none-any.whl (18 kB)
Collecting pre-commit
  Downloading pre_commit-2.10.1-py2.py3-none-any.whl (185 kB)
Collecting pylint<2.8
  Downloading pylint-2.7.2-py3-none-any.whl (342 kB)
Collecting pytest<3.7.0
  Downloading pytest-3.6.4-py2.py3-none-any.whl (196 kB)
Requirement already satisfied: setuptools in /usr/lib/python3/dist-packages (from -r requirements-dev.txt (line 8)) (45.2.0)
Collecting sphinx_rtd_theme
  Downloading sphinx_rtd_theme-0.5.1-py2.py3-none-any.whl (2.8 MB)
Collecting tox==3.22.0
  Downloading tox-3.22.0-py2.py3-none-any.whl (84 kB)
Collecting pytz
  Downloading pytz-2021.1-py2.py3-none-any.whl (510 kB)
Requirement already satisfied: six>=1.4.0 in /usr/lib/python3/dist-packages (from apscheduler>=3.3.0->-r requirements.txt (line 1)) (1.14.0)
Collecting botocore<1.21.0,>=1.20.18
  Downloading botocore-1.20.18-py2.py3-none-any.whl (7.3 MB)
Collecting s3transfer<0.4.0,>=0.3.0
  Downloading s3transfer-0.3.4-py2.py3-none-any.whl (69 kB)
Collecting jmespath<1.0.0,>=0.7.1
  Downloading jmespath-0.10.0-py2.py3-none-any.whl (24 kB)
Collecting pycparser
  Downloading pycparser-2.20-py2.py3-none-any.whl (112 kB)
Collecting future
  Downloading future-0.18.2.tar.gz (829 kB)
Collecting natsort
  Downloading natsort-7.1.1-py3-none-any.whl (35 kB)
Requirement already satisfied: urllib3>=1.21.1 in /usr/lib/python3/dist-packages (from elasticsearch==7.0.0->-r requirements.txt (line 8)) (1.25.8)
Collecting MarkupSafe>=0.23
  Downloading MarkupSafe-1.1.1-cp38-cp38-manylinux2010_x86_64.whl (32 kB)
Collecting requests-oauthlib>=0.6.1
  Downloading requests_oauthlib-1.3.0-py2.py3-none-any.whl (23 kB)
Collecting oauthlib[signedtoken]>=1.0.0
  Downloading oauthlib-3.1.0-py2.py3-none-any.whl (147 kB)
Collecting defusedxml
  Downloading defusedxml-0.6.0-py2.py3-none-any.whl (23 kB)
Collecting pbr>=3.0.0
  Downloading pbr-5.5.1-py2.py3-none-any.whl (106 kB)
Collecting requests-toolbelt
  Downloading requests_toolbelt-0.9.1-py2.py3-none-any.whl (54 kB)
Collecting pyrsistent>=0.14.0
  Downloading pyrsistent-0.17.3.tar.gz (106 kB)
Collecting attrs>=17.4.0
  Downloading attrs-20.3.0-py2.py3-none-any.whl (49 kB)
Collecting docopt<0.7.0,>=0.6.2
  Downloading docopt-0.6.2.tar.gz (25 kB)
Collecting PyJWT>=1.4.2
  Downloading PyJWT-2.0.1-py3-none-any.whl (15 kB)
Collecting pysocks
  Downloading PySocks-1.7.1-py3-none-any.whl (16 kB)
Collecting pycodestyle<2.7.0,>=2.6.0a1
  Downloading pycodestyle-2.6.0-py2.py3-none-any.whl (41 kB)
Collecting mccabe<0.7.0,>=0.6.0
  Downloading mccabe-0.6.1-py2.py3-none-any.whl (8.6 kB)
Collecting pyflakes<2.3.0,>=2.2.0
  Downloading pyflakes-2.2.0-py2.py3-none-any.whl (66 kB)
Collecting identify>=1.0.0
  Downloading identify-2.0.0-py2.py3-none-any.whl (97 kB)
Collecting virtualenv>=20.0.8
  Downloading virtualenv-20.4.2-py2.py3-none-any.whl (7.2 MB)
Collecting toml
  Downloading toml-0.10.2-py2.py3-none-any.whl (16 kB)
Collecting cfgv>=2.0.0
  Downloading cfgv-3.2.0-py2.py3-none-any.whl (7.3 kB)
Collecting nodeenv>=0.11.1
  Downloading nodeenv-1.5.0-py2.py3-none-any.whl (21 kB)
Collecting astroid<2.6,>=2.5.1
  Downloading astroid-2.5.1-py3-none-any.whl (222 kB)
Collecting isort<6,>=4.2.5
  Downloading isort-5.7.0-py3-none-any.whl (104 kB)
Collecting atomicwrites>=1.0
  Downloading atomicwrites-1.4.0-py2.py3-none-any.whl (6.8 kB)
Collecting py>=1.5.0
  Downloading py-1.10.0-py2.py3-none-any.whl (97 kB)
Collecting more-itertools>=4.0.0
  Downloading more_itertools-8.7.0-py3-none-any.whl (48 kB)
Collecting sphinx
  Downloading Sphinx-3.5.1-py3-none-any.whl (2.8 MB)
Collecting packaging>=14
  Downloading packaging-20.9-py2.py3-none-any.whl (40 kB)
Collecting filelock>=3.0.0
  Downloading filelock-3.0.12-py3-none-any.whl (7.6 kB)
Collecting cryptography; extra == "signedtoken"
  Downloading cryptography-3.4.6-cp36-abi3-manylinux2014_x86_64.whl (3.2 MB)
Collecting distlib<1,>=0.3.1
  Downloading distlib-0.3.1-py2.py3-none-any.whl (335 kB)
Collecting appdirs<2,>=1.4.3
  Downloading appdirs-1.4.4-py2.py3-none-any.whl (9.6 kB)
Collecting wrapt<1.13,>=1.11
  Downloading wrapt-1.12.1.tar.gz (27 kB)
Collecting lazy-object-proxy>=1.4.0
  Downloading lazy_object_proxy-1.5.2-cp38-cp38-manylinux1_x86_64.whl (54 kB)
Collecting sphinxcontrib-applehelp
  Downloading sphinxcontrib_applehelp-1.0.2-py2.py3-none-any.whl (121 kB)
Collecting snowballstemmer>=1.1
  Downloading snowballstemmer-2.1.0-py2.py3-none-any.whl (93 kB)
Collecting sphinxcontrib-jsmath
  Downloading sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl (5.1 kB)
Collecting Pygments>=2.0
  Downloading Pygments-2.8.0-py3-none-any.whl (983 kB)
Collecting sphinxcontrib-devhelp
  Downloading sphinxcontrib_devhelp-1.0.2-py2.py3-none-any.whl (84 kB)
Collecting alabaster<0.8,>=0.7
  Downloading alabaster-0.7.12-py2.py3-none-any.whl (14 kB)
Collecting sphinxcontrib-qthelp
  Downloading sphinxcontrib_qthelp-1.0.3-py2.py3-none-any.whl (90 kB)
Collecting imagesize
  Downloading imagesize-1.2.0-py2.py3-none-any.whl (4.8 kB)
Collecting babel>=1.3
  Downloading Babel-2.9.0-py2.py3-none-any.whl (8.8 MB)
Collecting sphinxcontrib-serializinghtml
  Downloading sphinxcontrib_serializinghtml-1.1.4-py2.py3-none-any.whl (89 kB)
Collecting sphinxcontrib-htmlhelp
  Downloading sphinxcontrib_htmlhelp-1.0.3-py2.py3-none-any.whl (96 kB)
Collecting docutils>=0.12
  Downloading docutils-0.16-py2.py3-none-any.whl (548 kB)
Collecting pyparsing>=2.0.2
  Downloading pyparsing-2.4.7-py2.py3-none-any.whl (67 kB)
Building wheels for collected packages: envparse, exotel, PyStaticConfiguration, twilio, future, pyrsistent, docopt, wrapt
  Building wheel for envparse (setup.py): started
  Building wheel for envparse (setup.py): finished with status 'done'
  Created wheel for envparse: filename=envparse-0.2.0-py2.py3-none-any.whl size=7009 sha256=c63406cc1df45a16c448304beb1d41d100ce59fa57ecca691366517457a1113b
  Stored in directory: /root/.cache/pip/wheels/76/9c/3a/65bc2654628ca3e0df9bb430847a6d2c859191ffba5b32aa1b
  Building wheel for exotel (setup.py): started
  Building wheel for exotel (setup.py): finished with status 'done'
  Created wheel for exotel: filename=exotel-0.1.5-py3-none-any.whl size=2721 sha256=23bee517af7e3ec1afa62e533610b1c99dad10b152d1f0e94e558c7468e6a3c1
  Stored in directory: /root/.cache/pip/wheels/59/93/51/054a93919dbfefe4e6df62a8d43998aeedad39c85e3f241d03
  Building wheel for PyStaticConfiguration (setup.py): started
  Building wheel for PyStaticConfiguration (setup.py): finished with status 'done'
  Created wheel for PyStaticConfiguration: filename=PyStaticConfiguration-0.10.5-py2.py3-none-any.whl size=24834 sha256=f3ba4c8606510e972010fa76de61646333c028f0a4beb25505e59d64a47320a1
  Stored in directory: /root/.cache/pip/wheels/f5/d6/ca/1e9eb13941d23cec1d70a553f6526dfcb0efd051291a1f3a85
  Building wheel for twilio (setup.py): started
  Building wheel for twilio (setup.py): finished with status 'done'
  Created wheel for twilio: filename=twilio-6.0.0-py2.py3-none-any.whl size=622092 sha256=1b651cfa63ec151e0f5a399d56c9b872c1d461358fea59a41eba2c68862ef363
  Stored in directory: /root/.cache/pip/wheels/c8/f9/86/215fd9c665016f0c6d4a08792350664959e500b9121daba9c7
  Building wheel for future (setup.py): started
  Building wheel for future (setup.py): finished with status 'done'
  Created wheel for future: filename=future-0.18.2-py3-none-any.whl size=491058 sha256=7f7248b8b03ef3c01663b643d71bbe8330083be6b30517fe432f2654dbd823e9
  Stored in directory: /root/.cache/pip/wheels/8e/70/28/3d6ccd6e315f65f245da085482a2e1c7d14b90b30f239e2cf4
  Building wheel for pyrsistent (setup.py): started
  Building wheel for pyrsistent (setup.py): finished with status 'done'
  Created wheel for pyrsistent: filename=pyrsistent-0.17.3-cp38-cp38-linux_x86_64.whl size=106653 sha256=af3fa2617d361ba04954c59bed58069f98e2e5fe4173dfb338bf8c5fd518981e
  Stored in directory: /root/.cache/pip/wheels/3d/22/08/7042eb6309c650c7b53615d5df5cc61f1ea9680e7edd3a08d2
  Building wheel for docopt (setup.py): started
  Building wheel for docopt (setup.py): finished with status 'done'
  Created wheel for docopt: filename=docopt-0.6.2-py2.py3-none-any.whl size=13704 sha256=9d8969e7f4c9ca36a11d640cf55c7b6f92e3d89ef64b04c65256284c57e501b0
  Stored in directory: /root/.cache/pip/wheels/56/ea/58/ead137b087d9e326852a851351d1debf4ada529b6ac0ec4e8c
  Building wheel for wrapt (setup.py): started
  Building wheel for wrapt (setup.py): finished with status 'done'
  Created wheel for wrapt: filename=wrapt-1.12.1-cp38-cp38-linux_x86_64.whl size=78509 sha256=ca681a7d1533cae8549aed99eeb52d29949d55da63c776a6a708facd8bcfa590
  Stored in directory: /root/.cache/pip/wheels/5f/fd/9e/b6cf5890494cb8ef0b5eaff72e5d55a70fb56316007d6dfe73
Successfully built envparse exotel PyStaticConfiguration twilio future pyrsistent docopt wrapt
ERROR: pytest 3.6.4 has requirement pluggy<0.8,>=0.5, but you'll have pluggy 0.13.1 which is incompatible.
Installing collected packages: pytz, tzlocal, apscheduler, aws-requests-auth, sortedcontainers, python-dateutil, jmespath, botocore, s3transfer, boto3, pycparser, cffi, configparser, future, natsort, croniter, elasticsearch, envparse, exotel, MarkupSafe, Jinja2, cryptography, PyJWT, oauthlib, requests-oauthlib, defusedxml, pbr, requests-toolbelt, jira, pyrsistent, attrs, jsonschema, mock, prison, py-zabbix, PyStaticConfiguration, PyYAML, docopt, stomp.py, texttable, pysocks, twilio, coverage, pycodestyle, mccabe, pyflakes, flake8, pluggy, identify, distlib, appdirs, filelock, virtualenv, toml, cfgv, nodeenv, pre-commit, wrapt, lazy-object-proxy, astroid, isort, pylint, atomicwrites, py, more-itertools, pytest, sphinxcontrib-applehelp, snowballstemmer, sphinxcontrib-jsmath, Pygments, sphinxcontrib-devhelp, pyparsing, packaging, alabaster, sphinxcontrib-qthelp, imagesize, babel, sphinxcontrib-serializinghtml, sphinxcontrib-htmlhelp, docutils, sphinx, sphinx-rtd-theme, tox
Successfully installed Jinja2-2.10.1 MarkupSafe-1.1.1 PyJWT-2.0.1 PyStaticConfiguration-0.10.5 PyYAML-5.4.1 Pygments-2.8.0 alabaster-0.7.12 appdirs-1.4.4 apscheduler-3.7.0 astroid-2.5.1 atomicwrites-1.4.0 attrs-20.3.0 aws-requests-auth-0.4.3 babel-2.9.0 boto3-1.17.18 botocore-1.20.18 cffi-1.14.5 cfgv-3.2.0 configparser-5.0.2 coverage-5.5 croniter-1.0.6 cryptography-3.4.6 defusedxml-0.6.0 distlib-0.3.1 docopt-0.6.2 docutils-0.16 elasticsearch-7.0.0 envparse-0.2.0 exotel-0.1.5 filelock-3.0.12 flake8-3.8.4 future-0.18.2 identify-2.0.0 imagesize-1.2.0 isort-5.7.0 jira-2.0.0 jmespath-0.10.0 jsonschema-3.2.0 lazy-object-proxy-1.5.2 mccabe-0.6.1 mock-4.0.3 more-itertools-8.7.0 natsort-7.1.1 nodeenv-1.5.0 oauthlib-3.1.0 packaging-20.9 pbr-5.5.1 pluggy-0.13.1 pre-commit-2.10.1 prison-0.1.3 py-1.10.0 py-zabbix-1.1.7 pycodestyle-2.6.0 pycparser-2.20 pyflakes-2.2.0 pylint-2.7.2 pyparsing-2.4.7 pyrsistent-0.17.3 pysocks-1.7.1 pytest-3.6.4 python-dateutil-2.6.1 pytz-2021.1 requests-oauthlib-1.3.0 requests-toolbelt-0.9.1 s3transfer-0.3.4 snowballstemmer-2.1.0 sortedcontainers-2.3.0 sphinx-3.5.1 sphinx-rtd-theme-0.5.1 sphinxcontrib-applehelp-1.0.2 sphinxcontrib-devhelp-1.0.2 sphinxcontrib-htmlhelp-1.0.3 sphinxcontrib-jsmath-1.0.1 sphinxcontrib-qthelp-1.0.3 sphinxcontrib-serializinghtml-1.1.4 stomp.py-6.1.0 texttable-1.6.3 toml-0.10.2 tox-3.22.0 twilio-6.0.0 tzlocal-2.1 virtualenv-20.4.2 wrapt-1.12.1
Removing intermediate container 502237d55900
 ---> af6d7294800f
Successfully built af6d7294800f
Successfully tagged elastalert_tox:latest
docker-compose --project-name elastalert run tox
GLOB sdist-make: /home/elastalert/setup.py
py39 create: /home/elastalert/.tox/py39
py39 installdeps: -rrequirements-dev.txt
py39 inst: /home/elastalert/.tox/.tmp/package/1/elastalert-0.2.4.zip
py39 installed: alabaster==0.7.12,appdirs==1.4.4,APScheduler==3.7.0,astroid==2.5.1,attrs==20.3.0,aws-requests-auth==0.4.3,Babel==2.9.0,boto3==1.17.18,botocore==1.20.18,certifi==2020.12.5,cffi==1.14.5,cfgv==3.2.0,chardet==4.0.0,configparser==5.0.2,coverage==5.5,croniter==1.0.6,cryptography==3.4.6,defusedxml==0.6.0,distlib==0.3.1,docopt==0.6.2,docutils==0.16,elastalert @ file:///home/elastalert/.tox/.tmp/package/1/elastalert-0.2.4.zip,elasticsearch==7.0.0,envparse==0.2.0,exotel==0.1.5,filelock==3.0.12,flake8==3.8.4,future==0.18.2,identify==2.0.0,idna==2.10,imagesize==1.2.0,isort==5.7.0,Jinja2==2.10.1,jira==2.0.0,jmespath==0.10.0,jsonschema==3.2.0,lazy-object-proxy==1.5.2,MarkupSafe==1.1.1,mccabe==0.6.1,mock==4.0.3,natsort==7.1.1,nodeenv==1.5.0,oauthlib==3.1.0,packaging==20.9,pbr==5.5.1,pluggy==0.13.1,pre-commit==2.10.1,prison==0.1.3,py==1.10.0,py-zabbix==1.1.7,pycodestyle==2.6.0,pycparser==2.20,pyflakes==2.2.0,Pygments==2.8.0,PyJWT==2.0.1,pylint==2.7.2,pyparsing==2.4.7,pyrsistent==0.17.3,PySocks==1.7.1,PyStaticConfiguration==0.10.5,pytest==3.2.5,python-dateutil==2.6.1,pytz==2021.1,PyYAML==5.4.1,requests==2.25.1,requests-oauthlib==1.3.0,requests-toolbelt==0.9.1,s3transfer==0.3.4,six==1.15.0,snowballstemmer==2.1.0,sortedcontainers==2.3.0,Sphinx==3.5.1,sphinx-rtd-theme==0.5.1,sphinxcontrib-applehelp==1.0.2,sphinxcontrib-devhelp==1.0.2,sphinxcontrib-htmlhelp==1.0.3,sphinxcontrib-jsmath==1.0.1,sphinxcontrib-qthelp==1.0.3,sphinxcontrib-serializinghtml==1.1.4,stomp.py==6.1.0,texttable==1.6.3,toml==0.10.2,tox==3.22.0,twilio==6.0.0,tzlocal==2.1,urllib3==1.26.3,virtualenv==20.4.2,wrapt==1.12.1
py39 run-test-pre: PYTHONHASHSEED='3200695130'
py39 run-test: commands[0] | coverage run --source=elastalert/,tests/ -m pytest --strict
========================================================================== test session starts ==========================================================================
platform linux -- Python 3.9.2, pytest-3.2.5, py-1.10.0, pluggy-0.4.0
rootdir: /home/elastalert, inifile: pytest.ini
collected 254 items                                                                                                                                                      

tests/alerts_test.py .........................................................
tests/auth_test.py ...
tests/base_test.py ........................................................
tests/create_index_test.py ..................
tests/elasticsearch_test.py ssss
tests/kibana_discover_test.py .........................................
tests/kibana_test.py ....
tests/loaders_test.py .....................
tests/rules_test.py ..................................
tests/util_test.py ................

================================================================ 250 passed, 4 skipped in 22.55 seconds =================================================================
py39 run-test: commands[1] | coverage report -m
Name                             Stmts   Miss  Cover   Missing
--------------------------------------------------------------
elastalert/__init__.py              61     40    34%   19-32, 39, 46-55, 61, 67, 73-74, 80-81, 87, 93-103, 247-257
elastalert/alerts.py              1382    602    56%   46-49, 70, 113, 142, 204, 215, 220, 265, 270, 275-300, 313, 318, 329-384, 387, 394-401, 404, 444-445, 452, 461-470, 486-489, 492, 500-503, 521, 599-606, 617, 625-626, 637, 648, 669, 684, 691, 704, 711, 737-741, 746, 761, 764, 782-785, 804-805, 811-812, 817-818, 820-824, 827-828, 831, 854, 858-859, 868, 874, 881, 886, 895, 900, 923-924, 934-935, 939, 942, 951-957, 960-961, 964-981, 1026-1027, 1031, 1069-1071, 1076, 1080-1085, 1112, 1115, 1120, 1123, 1138, 1151-1152, 1156, 1165-1182, 1185-1187, 1190-1193, 1196-1208, 1211-1261, 1264, 1309-1311, 1361-1362, 1366-1369, 1373-1384, 1395-1397, 1406, 1415-1417, 1421-1436, 1439, 1447-1452, 1455-1464, 1467, 1474-1478, 1481-1491, 1494, 1503-1511, 1514-1534, 1537, 1546-1553, 1556-1584, 1588, 1597-1605, 1608-1615, 1618-1633, 1636-1653, 1656-1657, 1661-1674, 1677, 1686-1689, 1692-1708, 1711, 1731-1733, 1736-1767, 1770, 1809, 1819-1820, 1824-1830, 1833, 1851, 1855, 1879-1880, 1914, 1926-1927, 1931, 1940-1941, 1944-1958, 1961, 1973-2035, 2039, 2050-2058, 2061-2099, 2103, 2112-2122, 2125, 2128-2188, 2191, 2202-2208, 2211-2226, 2230
elastalert/auth.py                  26      3    88%   28, 32, 36
elastalert/config.py                73     20    73%   47-50, 61-62, 65, 69, 84, 88, 91-92, 101, 111, 114, 125, 131, 134-136
elastalert/create_index.py         157    127    19%   23-113, 137, 141-142, 146, 150-264, 268
elastalert/elastalert.py          1284    418    67%   123, 128, 131, 140-142, 181-182, 184, 188, 240, 247-248, 255-287, 295-309, 328, 333, 350-351, 387, 398, 406-412, 419, 433, 470, 474-479, 484-503, 528-536, 543, 552-594, 629, 631, 647, 662, 664, 670-674, 677-681, 705-708, 718-719, 761, 765-768, 774-784, 803, 819-822, 837, 852, 884, 895-896, 915, 918-919, 924, 957, 992-996, 1002-1011, 1015-1019, 1073, 1087-1095, 1101-1102, 1104-1128, 1149-1150, 1152, 1162, 1170-1177, 1194-1197, 1200, 1246-1251, 1254-1256, 1260-1262, 1265-1324, 1328-1334, 1346-1347, 1351-1360, 1404-1407, 1434, 1439-1440, 1458, 1464-1471, 1477-1478, 1487, 1494-1512, 1516-1525, 1528-1530, 1533-1535, 1547-1550, 1553, 1557-1559, 1571-1573, 1599, 1602-1605, 1621, 1631-1632, 1640, 1660, 1666, 1672-1674, 1685-1687, 1695, 1722, 1725-1726, 1731-1740, 1755, 1763, 1766-1767, 1778, 1782, 1787-1791, 1806-1810, 1826-1827, 1873-1874, 1877-1878, 1883, 1889-1891, 1894-1895, 1916, 1920, 1929-1933, 1938-1941, 1943-1950, 1980-1981, 1983-1991, 1994, 2010-2011, 2064, 2069-2071, 2075-2080, 2084
elastalert/enhancements.py          11      2    82%   15, 20
elastalert/kibana.py                79     12    85%   209-210, 232-238, 268, 271, 274, 279
elastalert/kibana_discover.py       61      0   100%
elastalert/loaders.py              325     90    72%   124-125, 127, 144, 154, 163, 172, 218, 242, 247, 251, 253, 255, 257, 259, 261, 263, 268-269, 293-314, 318-321, 325, 328, 341-342, 345-346, 356, 362, 375, 386-387, 392-394, 400, 404, 411-417, 426, 432, 436-437, 455, 460, 485-490, 502, 509, 520-524, 529-530, 545-551
elastalert/opsgenie.py             137     24    82%   52-53, 60, 68, 73, 92, 98, 122-123, 130-132, 139, 144-158
elastalert/rule_from_kibana.py      29     29     0%   3-47
elastalert/ruletypes.py            767    187    76%   46, 77, 84, 90, 95, 109-112, 119, 226, 271, 284-291, 334, 343-354, 358-361, 365-368, 371, 376-396, 422, 441, 443-451, 463-468, 499-505, 522-523, 538-539, 553-568, 573-583, 632-640, 665-667, 671, 673, 676, 678-682, 686-688, 697, 699, 714-715, 726, 737, 742, 758-761, 763, 771-781, 939, 988, 992-1003, 1022, 1032, 1056, 1074, 1076, 1081-1088, 1093, 1102, 1115, 1156-1170, 1174-1179, 1187-1198, 1205-1227, 1233-1240
elastalert/test_rule.py            282    251    11%   37-41, 46-47, 52-167, 171-175, 179-197, 201-216, 220-223, 231-337, 343-440, 444-445, 449
elastalert/util.py                 257     74    71%   29-30, 155-156, 168-174, 178-182, 196-198, 260, 264, 268-269, 273, 324-332, 340-393, 399-402, 451
elastalert/zabbix.py                58     46    21%   13-20, 26-41, 52-60, 68-89, 95
tests/__init__.py                    0      0   100%
tests/alerts_test.py               819      0   100%
tests/auth_test.py                  11      0   100%
tests/base_test.py                 912      2    99%   31-32
tests/conftest.py                  152     13    91%   26-29, 103-111
tests/create_index_test.py          31      0   100%
tests/elasticsearch_test.py         71     46    35%   24-25, 35-51, 55-71, 75-88, 92-102
tests/kibana_discover_test.py       86      0   100%
tests/kibana_test.py                28      0   100%
tests/loaders_test.py              299      0   100%
tests/rules_test.py                715      0   100%
tests/util_test.py                  96      0   100%
--------------------------------------------------------------
TOTAL                             8209   1986    76%
py39 run-test: commands[2] | flake8 .
docs create: /home/elastalert/.tox/docs
docs installdeps: -rrequirements-dev.txt, sphinx==1.6.6
docs inst: /home/elastalert/.tox/.tmp/package/1/elastalert-0.2.4.zip
docs installed: alabaster==0.7.12,appdirs==1.4.4,APScheduler==3.7.0,astroid==2.5.1,attrs==20.3.0,aws-requests-auth==0.4.3,Babel==2.9.0,boto3==1.17.18,botocore==1.20.18,certifi==2020.12.5,cffi==1.14.5,cfgv==3.2.0,chardet==4.0.0,configparser==5.0.2,coverage==5.5,croniter==1.0.6,cryptography==3.4.6,defusedxml==0.6.0,distlib==0.3.1,docopt==0.6.2,docutils==0.16,elastalert @ file:///home/elastalert/.tox/.tmp/package/1/elastalert-0.2.4.zip,elasticsearch==7.0.0,envparse==0.2.0,exotel==0.1.5,filelock==3.0.12,flake8==3.8.4,future==0.18.2,identify==2.0.0,idna==2.10,imagesize==1.2.0,isort==5.7.0,Jinja2==2.10.1,jira==2.0.0,jmespath==0.10.0,jsonschema==3.2.0,lazy-object-proxy==1.5.2,MarkupSafe==1.1.1,mccabe==0.6.1,mock==4.0.3,natsort==7.1.1,nodeenv==1.5.0,oauthlib==3.1.0,packaging==20.9,pbr==5.5.1,pluggy==0.13.1,pre-commit==2.10.1,prison==0.1.3,py==1.10.0,py-zabbix==1.1.7,pycodestyle==2.6.0,pycparser==2.20,pyflakes==2.2.0,Pygments==2.8.0,PyJWT==2.0.1,pylint==2.7.2,pyparsing==2.4.7,pyrsistent==0.17.3,PySocks==1.7.1,PyStaticConfiguration==0.10.5,pytest==3.2.5,python-dateutil==2.6.1,pytz==2021.1,PyYAML==5.4.1,requests==2.25.1,requests-oauthlib==1.3.0,requests-toolbelt==0.9.1,s3transfer==0.3.4,six==1.15.0,snowballstemmer==2.1.0,sortedcontainers==2.3.0,Sphinx==1.6.6,sphinx-rtd-theme==0.5.1,sphinxcontrib-serializinghtml==1.1.4,sphinxcontrib-websupport==1.2.4,stomp.py==6.1.0,texttable==1.6.3,toml==0.10.2,tox==3.22.0,twilio==6.0.0,tzlocal==2.1,urllib3==1.26.3,virtualenv==20.4.2,wrapt==1.12.1
docs run-test-pre: PYTHONHASHSEED='3200695130'
docs run-test: commands[0] | sphinx-build -b html -d build/doctrees -W source build/html
Running Sphinx v1.6.6
making output directory...
loading pickled environment... not yet created
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 12 source files that are out of date
updating environment: 12 added, 0 changed, 0 removed
reading sources... [  8%] elastalert
reading sources... [ 16%] elastalert_status
reading sources... [ 25%] elasticsearch_security_privileges
reading sources... [ 33%] index
reading sources... [ 41%] recipes/adding_alerts
reading sources... [ 50%] recipes/adding_enhancements
reading sources... [ 58%] recipes/adding_loaders
reading sources... [ 66%] recipes/adding_rules
reading sources... [ 75%] recipes/signing_requests
reading sources... [ 83%] recipes/writing_filters
reading sources... [ 91%] ruletypes
reading sources... [100%] running_elastalert
/home/elastalert/.tox/docs/lib/python3.8/site-packages/sphinx/util/nodes.py:55: FutureWarning: 
   The iterable returned by Node.traverse()
   will become an iterator instead of a list in Docutils > 0.16.
  for classifier in reversed(node.parent.traverse(nodes.classifier)):

looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [  8%] elastalert
writing output... [ 16%] elastalert_status
writing output... [ 25%] elasticsearch_security_privileges
writing output... [ 33%] index
writing output... [ 41%] recipes/adding_alerts
writing output... [ 50%] recipes/adding_enhancements
writing output... [ 58%] recipes/adding_loaders
writing output... [ 66%] recipes/adding_rules
writing output... [ 75%] recipes/signing_requests
writing output... [ 83%] recipes/writing_filters
writing output... [ 91%] ruletypes
writing output... [100%] running_elastalert

generating indices... genindex
writing additional pages... search
copying static files... done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded.
________________________________________________________________________________ summary ________________________________________________________________________________
  py39: commands succeeded
  docs: commands succeeded
  congratulations :)
```