### PR TITLE
Remove unused items in alerta from schema.yaml

### DIFF
--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -352,14 +352,12 @@ properties:
   alerta_correlate: {type: array, items: {type: string}}  # Python format string
   alerta_tags: {type: array, items: {type: string}}   # Python format string
   alerta_event: {type: string} # Python format string
-  alerta_customer: {type: string}
   alerta_text: {type: string} # Python format string
   alerta_type: {type: string}
   alerta_value: {type: string} # Python format string
   alerta_attributes_keys: {type: array, items: {type: string}}
   alerta_attributes_values: {type: array, items: {type: string}}  # Python format string
-  alerta_new_style_string_format: {type: boolean}
-
+  
 
   ### Simple
   simple_webhook_url: *arrayOfString

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -357,7 +357,6 @@ properties:
   alerta_value: {type: string} # Python format string
   alerta_attributes_keys: {type: array, items: {type: string}}
   alerta_attributes_values: {type: array, items: {type: string}}  # Python format string
-  
 
   ### Simple
   simple_webhook_url: *arrayOfString

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -2220,7 +2220,6 @@ def test_alerta_new_style(ea):
         'alerta_severity': "debug",
         'alerta_text': "Probe {hostname} is UP at {logdate} GMT",
         'alerta_value': "UP",
-        'alerta_new_style_string_format': True,
         'type': 'any',
         'alerta_use_match_timestamp': True,
         'alert': 'alerta'


### PR DESCRIPTION
**schema.yaml**

- alerta_new_style_string_format has been removed in 0.1.31
- alerta_customer is not used

```
alerta_new_style_string_format
alerta_customer
```
**tests/alerts_test.py**

remove code

```
'alerta_new_style_string_format': True,
```


