### PR TITLE
Fix search syntax on aggregations

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1748,7 +1748,7 @@ class ElastAlerter(object):
         """ Removes and returns all matches from writeback_es that have aggregate_id == _id """
 
         # XXX if there are more than self.max_aggregation matches, you have big alerts and we will leave entries in ES.
-        query = {'query': {'query_string': {'query': 'aggregate_id:%s' % (_id)}}, 'sort': {'@timestamp': 'asc'}}
+        query = {'query': {'query_string': {'query': 'aggregate_id:"%s"' % (_id)}}, 'sort': {'@timestamp': 'asc'}}
         matches = []
         try:
             if self.writeback_es.is_atleastsixtwo():

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -427,8 +427,8 @@ def test_agg_matchtime(ea):
     call4 = ea.writeback_es.deprecated_search.call_args_list[10][1]['body']
 
     assert 'alert_time' in call2['filter']['range']
-    assert call3['query']['query_string']['query'] == 'aggregate_id:ABCD'
-    assert call4['query']['query_string']['query'] == 'aggregate_id:CDEF'
+    assert call3['query']['query_string']['query'] == 'aggregate_id:"ABCD"'
+    assert call4['query']['query_string']['query'] == 'aggregate_id:"CDEF"'
     assert ea.writeback_es.deprecated_search.call_args_list[9][1]['size'] == 1337
 
 

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -596,8 +596,8 @@ def test_agg_with_aggregation_key(ea):
     call4 = ea.writeback_es.deprecated_search.call_args_list[10][1]['body']
 
     assert 'alert_time' in call2['filter']['range']
-    assert call3['query']['query_string']['query'] == 'aggregate_id:ABCD'
-    assert call4['query']['query_string']['query'] == 'aggregate_id:CDEF'
+    assert call3['query']['query_string']['query'] == 'aggregate_id:"ABCD"'
+    assert call4['query']['query_string']['query'] == 'aggregate_id:"CDEF"'
     assert ea.writeback_es.deprecated_search.call_args_list[9][1]['size'] == 1337
 
 


### PR DESCRIPTION
This brings in a change that's been applied on other forks (and opened on the
main Elastalert repo, but not merged):

https://github.com/skillz/elastalert/pull/1
https://github.com/Yelp/elastalert/pull/2038

Without this fix, syntax errors are generated when document IDs that contain '-'
characters are seen by alerts that use the `aggregation` field.