### PR TITLE
allow loading jinja templates from filesystem

### DIFF
--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -220,6 +220,8 @@ The default value is ``.raw`` for Elasticsearch 2 and ``.keyword`` for Elasticse
 
 ``jinja_root_name``: When using a Jinja template, specify the name of the root field name in the template. The default is ``_data``.
 
+``jinja_template_path``: When using a Jinja template, specify filesystem path to template, this overrides the default behaviour of using alert_text as the template.
+
 Logging
 -------
 

--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -9,6 +9,8 @@ import jsonschema
 import yaml
 import yaml.scanner
 from jinja2 import Template
+from jinja2 import Environment
+from jinja2 import FileSystemLoader
 from staticconf.loader import yaml_loader
 
 from . import alerts
@@ -94,6 +96,8 @@ class RulesLoader(object):
     }
 
     base_config = {}
+
+    jinja_environment = Environment(loader=FileSystemLoader(""))
 
     def __init__(self, conf):
         # schema for rule yaml
@@ -401,7 +405,11 @@ class RulesLoader(object):
 
         # Compile Jinja Template
         if rule.get('alert_text_type') == 'alert_text_jinja':
-            rule["jinja_template"] = Template(str(rule.get('alert_text', '')))
+            jinja_template_path = rule.get('jinja_template_path')
+            if jinja_template_path:
+                rule["jinja_template"] = self.jinja_environment.get_or_select_template(jinja_template_path)
+            else:
+                rule["jinja_template"] = Template(str(rule.get('alert_text', '')))
 
     def load_modules(self, rule, args=None):
         """ Loads things that could be modules. Enhancements, alerts and rule type. """


### PR DESCRIPTION
This PR allows for referencing jinja templates by filesystem.
This mechanism also allows for template inheritance.
Existing embedded templates are unaffected.

Readme/Contributing mentions writing tests, though there are no existing tests relating to jinja.

To use, in rule yaml: 
alert_text_type: "alert_text_jinja"
jinja_template_path: "path/to/template"

