### PR TITLE
apscheduler>=3.3.0 to >=3.3.0,<4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-apscheduler>=3.3.0
+apscheduler>=3.3.0,<4.0
 aws-requests-auth>=0.3.0
 sortedcontainers>=2.2.2
 boto3>=1.4.4

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     packages=find_packages(),
     package_data={'elastalert': ['schema.yaml', 'es_mappings/**/*.json']},
     install_requires=[
-        'apscheduler>=3.3.0',
+        'apscheduler>=3.3.0,<4.0',
         'aws-requests-auth>=0.3.0',
         'sortedcontainers>=2.2.2',
         'boto3>=1.4.4',


### PR DESCRIPTION
In APScheduler 3.x, it seems to be tzlocal <3.0, from APScheduler 4.0 to tzlocal => 3.0. Since it would be a problem if AP Schuler 4.0 stopped working when it was released, I changed the specification so that it does not go up to 4.0.

https://github.com/agronholm/apscheduler/issues/461#issuecomment-696880121
>That said, I do plan to pin tzlocal to <3.0 in APScheduler 3.x and >= 3.0 in APScheduler 4.0. I am the author of the breaking changes in tzlocal 3.0 btw :)