### PR TITLE
Update sphinx and elasticsearch-py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ boto3>=1.4.4
 cffi>=1.11.5
 configparser>=3.5.0
 croniter>=0.3.16
-elasticsearch==7.0.0
+elasticsearch>=7.0.0,<8.0.0
 envparse>=0.2.0
 exotel>=0.1.3
 Jinja2==2.11.3

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'boto3>=1.4.4',
         'configparser>=3.5.0',
         'croniter>=0.3.16',
-        'elasticsearch==7.0.0',
+        'elasticsearch>=7.0.0,<8.0.0',
         'envparse>=0.2.0',
         'exotel>=0.1.3',
         'jira>=2.0.0',

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,6 @@ norecursedirs = .* virtualenv_run docs build venv env
 
 [testenv:docs]
 deps = {[testenv]deps}
-    sphinx==1.6.6
+    sphinx==3.5.4
 changedir = docs
 commands = sphinx-build -b html -d build/doctrees -W source build/html


### PR DESCRIPTION
sphinx 1.6.6 to 3.5.4
elasticsearch 7.0.0 to >=7.0.0,<8.0.0


With the version upgrade of elasticsearch-py, the instruction that elasticsearch will be abolished in the major version upgrade will give the following warning, but if you are using the current version 7.xx, there is no problem in operation.
In addition, the following message will be displayed when the index of elastalert is newly created in elasitcsearch, so if you are already using elastalert, the message will not be displayed.

````
xxxx/elasticsearch/connection/base.py:193: ElasticsearchDeprecationWarning: Camel case format name dateOptionalTime is deprecated and will be removed in a future version. Use snake case name date_optional_time instead.
      warnings.warn(message, category=ElasticsearchDeprecationWarning)
    /home/node/.local/lib/python3.8/site-packages/elasticsearch/connection/base.py:193: ElasticsearchDeprecationWarning: [types removal] Using include_type_name in put mapping requests is deprecated. The parameter will be removed in the next major version.
      warnings.warn(message, category=ElasticsearchDeprecationWarning)
````